### PR TITLE
Add GitHub Actions workflow for multi-OS builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: Rust Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+    - name: Build
+      run: cargo build --release --all-targets
+    - name: Upload artifact Linux/macOS
+      if: runner.os != 'Windows'
+      uses: actions/upload-artifact@v3
+      with:
+        name: apftool-rs-${{ matrix.os }}
+        path: target/release/apftool-rs
+    - name: Upload artifact Windows
+      if: runner.os == 'Windows'
+      uses: actions/upload-artifact@v3
+      with:
+        name: apftool-rs-${{ matrix.os }}
+        path: target/release/apftool-rs.exe


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow located in `.github/workflows/build.yml`.

The workflow builds the Rust project on Linux, Windows, and macOS. It performs the following steps for each OS:
- Checks out the source code.
- Sets up the Rust stable toolchain.
- Builds the project in release mode (`cargo build --release --all-targets`).
- Uploads the compiled executable as an artifact named `apftool-rs-{os}`.

This will ensure that the project can be successfully built across all targeted platforms and provides easy access to the compiled binaries.