### PR TITLE
fix: Add brackets to fix operator precedence when printing version

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@ fn unpack_rkfw(buf: &[u8], dst_path: &str) -> Result<()> {
         "version: {}.{}.{}",
         buf[9],
         buf[8],
-        (buf[7] as u16) << 8 + buf[6] as u16
+        ((buf[7] as u16) << 8) + buf[6] as u16
     );
     // println!(
     //     "date: {}-{:02}-{:02} {:02}:{:02}:{:02}",


### PR DESCRIPTION
Rust operator precedence has `+` higher than `<<`, so the expression was parsed as:

```
(buf[7] as u16) << (8 + buf[6] as u16)
```

causing:

```
alexk@alexk apftool-rs % ./target/debug/afptool-rs ~/Downloads/update.img .
RKFW signature detected

thread 'main' panicked at src/lib.rs:118:9:
attempt to shift left with overflow
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Add parentheses to force the shift before the addition and fix the output:

```
alexk@alexk apftool-rs % ./target/debug/afptool-rs ~/Downloads/update.img .
RKFW signature detected
version: 17.23.4112
family: RK3566
00000066-000401ec BOOT                       (size: 262535)
000401ed-09f169f0 embedded-update.img        (size: 166553604)
```