### PR TITLE
fix: strip PARM header/trailer when extracting parameter.txt

### DIFF
--- a/src/pack.rs
+++ b/src/pack.rs
@@ -376,11 +376,25 @@ pub fn pack_rkaf(input_dir: &str, output_file: &str, model: &str, manufacturer: 
         } else {
             // Load file for first time
             let file_path = format!("{}/{}", input_dir, path);
-            let mut file_data = Vec::new();
+            let mut raw_data = Vec::new();
 
             File::open(&file_path)
                 .map_err(|e| anyhow!("Cannot open {}: {}", file_path, e))?
-                .read_to_end(&mut file_data)?;
+                .read_to_end(&mut raw_data)?;
+
+            // "parameter" partitions are stored PARM-wrapped in the image
+            let file_data = if name == "parameter" {
+                let content_len = raw_data.len() as u32;
+                let mut wrapped = Vec::with_capacity(raw_data.len() + 12);
+                wrapped.extend_from_slice(b"PARM");
+                wrapped.extend_from_slice(&content_len.to_le_bytes());
+                wrapped.extend_from_slice(&raw_data);
+                let crc = rkcrc32(0, &raw_data);
+                wrapped.extend_from_slice(&crc.to_le_bytes());
+                wrapped
+            } else {
+                raw_data
+            };
 
             let file_size = file_data.len() as u32;
             let padded_size = ((file_size + sector_size as u32 - 1) / sector_size as u32) * sector_size as u32;

--- a/src/unpack.rs
+++ b/src/unpack.rs
@@ -147,6 +147,21 @@ fn extract_file(fp: &mut File, offset: u64, len: u64, full_path: &str) -> Result
     Ok(())
 }
 
+// Returns (data_offset, data_len) for the partition content, stripping the PARM
+// wrapper (4-byte magic + 4-byte content length + content + 4-byte CRC) for
+// partitions named "parameter", matching the behaviour of the reference rkafpack.c.
+fn parm_content_range(name: &str, fp: &mut File, offset: u64, len: u64) -> Result<(u64, u64)> {
+    const PARM_OVERHEAD: u64 = 12; // 4 magic + 4 length + 4 CRC
+    if name != "parameter" || len < PARM_OVERHEAD {
+        return Ok((offset, len));
+    }
+    let mut header = [0u8; 8];
+    fp.seek(std::io::SeekFrom::Start(offset))?;
+    fp.read_exact(&mut header)?;
+    let content_len = u32::from_le_bytes([header[4], header[5], header[6], header[7]]) as u64;
+    Ok((offset + 8, content_len))
+}
+
 fn unpack_rkafp(file_path: &str, dst_path: &str) -> Result<()> {
     use std::mem;
 
@@ -214,12 +229,13 @@ fn unpack_rkafp(file_path: &str, dst_path: &str) -> Result<()> {
             }
 
             let file_to_extract = format!("{}/{}", dst_path, part_full_path);
-            extract_file(
+            let (data_offset, data_len) = parm_content_range(
+                &part_name,
                 &mut fp,
                 part.part_offset as u64,
                 part.part_byte_count as u64,
-                &file_to_extract,
             )?;
+            extract_file(&mut fp, data_offset, data_len, &file_to_extract)?;
         }
     }
 

--- a/tests/lib_tests.rs
+++ b/tests/lib_tests.rs
@@ -3,7 +3,8 @@ mod tests {
     use std::fs::{self, File};
     use std::io::Write;
     use std::path::Path;
-    use afptool_rs::{RKAF_SIGNATURE, RKFW_SIGNATURE, UpdateHeader};
+    use afptool_rs::{pack_rkaf, unpack_file, RKAF_SIGNATURE, RKFW_SIGNATURE, UpdateHeader, UpdatePart};
+    use tempfile::TempDir;
 
     // 创建模拟的 RKFW 文件用于测试
     fn create_mock_rkfw() -> Vec<u8> {
@@ -173,5 +174,159 @@ mod tests {
         // 清理测试文件
         fs::remove_file(&rkfw_path).unwrap();
         fs::remove_file(&rkaf_path).unwrap();
+    }
+
+    #[test]
+    fn test_parm_header_stripped_on_extract() {
+        use std::mem;
+
+        let temp_dir = TempDir::new().unwrap();
+        let input_path = temp_dir.path().join("test.rkaf");
+        let output_dir = temp_dir.path().join("out");
+        fs::create_dir_all(&output_dir).unwrap();
+
+        let content = b"CMDLINE:console=ttyFIQ0,1500000\n";
+
+        // Build PARM-wrapped data: magic + content_len (LE u32) + content + CRC (4 bytes)
+        let mut parm_data: Vec<u8> = Vec::new();
+        parm_data.extend_from_slice(b"PARM");
+        parm_data.extend_from_slice(&(content.len() as u32).to_le_bytes());
+        parm_data.extend_from_slice(content);
+        parm_data.extend_from_slice(&[0u8; 4]); // CRC
+
+        let header_size = mem::size_of::<UpdateHeader>();
+
+        let mut header = UpdateHeader::default();
+        header.magic.copy_from_slice(RKAF_SIGNATURE);
+        header.num_parts = 1;
+        // header.length must equal filesize - 4 (the RKAF trailing CRC)
+        header.length = (header_size + parm_data.len()) as u32;
+
+        let mut part = UpdatePart::default();
+        part.name[..9].copy_from_slice(b"parameter");
+        part.full_path[..13].copy_from_slice(b"parameter.txt");
+        part.part_offset = header_size as u32;
+        part.part_byte_count = parm_data.len() as u32;
+        header.parts[0] = part;
+
+        let mut file_data: Vec<u8> = header.to_bytes().to_vec();
+        file_data.extend_from_slice(&parm_data);
+        file_data.extend_from_slice(&[0u8; 4]); // RKAF trailing CRC
+
+        fs::write(&input_path, &file_data).unwrap();
+
+        unpack_file(
+            input_path.to_str().unwrap(),
+            output_dir.to_str().unwrap(),
+        ).unwrap();
+
+        let extracted = fs::read(output_dir.join("parameter.txt")).unwrap();
+        assert_eq!(extracted, content, "extracted content should match without PARM wrapper");
+    }
+
+    #[test]
+    fn test_parameter_parm_wrapped_on_pack() {
+        let temp_dir = TempDir::new().unwrap();
+        let input_dir = temp_dir.path();
+        let output_file = temp_dir.path().join("out.rkaf");
+
+        let content = b"CMDLINE:console=ttyFIQ0,1500000\n";
+
+        fs::write(input_dir.join("parameter.txt"), content).unwrap();
+        fs::write(input_dir.join("package-file"), "parameter parameter.txt\n").unwrap();
+
+        // partition-metadata.txt provides flash_size/flash_offset/padded_size;
+        // part_byte_count in metadata is not used by pack (recomputed from file)
+        let wrapped_size = content.len() as u32 + 12;
+        let padded = ((wrapped_size + 2047) / 2048) * 2048;
+        fs::write(
+            input_dir.join("partition-metadata.txt"),
+            format!("parameter,parameter.txt,{:#010x},{:#010x},{:#010x},{:#010x},{:#010x}\n",
+                0u32, 0u32, 2048u32, padded, wrapped_size),
+        ).unwrap();
+
+        pack_rkaf(
+            input_dir.to_str().unwrap(),
+            output_file.to_str().unwrap(),
+            "RK3562",
+            "RK3562",
+        ).unwrap();
+
+        let rkaf = fs::read(&output_file).unwrap();
+        // UpdateHeader occupies exactly one 2048-byte sector; parameter data starts there
+        let param_data = &rkaf[2048..];
+        assert_eq!(&param_data[..4], b"PARM", "parameter partition must be PARM-wrapped");
+        let stored_len = u32::from_le_bytes(param_data[4..8].try_into().unwrap());
+        assert_eq!(stored_len as usize, content.len(), "PARM length field must hold bare content length");
+        assert_eq!(&param_data[8..8 + content.len()], content, "PARM content must match bare input");
+    }
+
+    #[test]
+    fn test_parameter_roundtrip() {
+        use std::mem;
+
+        let temp_dir = TempDir::new().unwrap();
+        let content = b"CMDLINE:console=ttyFIQ0,1500000\n";
+
+        // --- Build initial RKAF with PARM-wrapped parameter ---
+        let input_rkaf = temp_dir.path().join("original.rkaf");
+        let unpack_dir = temp_dir.path().join("unpacked");
+        let repack_file = temp_dir.path().join("repacked.rkaf");
+        let verify_dir = temp_dir.path().join("verified");
+
+        let mut parm_data: Vec<u8> = Vec::new();
+        parm_data.extend_from_slice(b"PARM");
+        parm_data.extend_from_slice(&(content.len() as u32).to_le_bytes());
+        parm_data.extend_from_slice(content);
+        parm_data.extend_from_slice(&[0u8; 4]); // CRC
+
+        let header_size = mem::size_of::<UpdateHeader>();
+        let mut header = UpdateHeader::default();
+        header.magic.copy_from_slice(RKAF_SIGNATURE);
+        header.num_parts = 1;
+        header.length = (header_size + parm_data.len()) as u32;
+
+        let mut part = UpdatePart::default();
+        part.name[..9].copy_from_slice(b"parameter");
+        part.full_path[..13].copy_from_slice(b"parameter.txt");
+        part.part_offset = header_size as u32;
+        part.part_byte_count = parm_data.len() as u32;
+        header.parts[0] = part;
+
+        let mut file_data: Vec<u8> = header.to_bytes().to_vec();
+        file_data.extend_from_slice(&parm_data);
+        file_data.extend_from_slice(&[0u8; 4]);
+        fs::write(&input_rkaf, &file_data).unwrap();
+
+        // --- Unpack ---
+        fs::create_dir_all(&unpack_dir).unwrap();
+        unpack_file(input_rkaf.to_str().unwrap(), unpack_dir.to_str().unwrap()).unwrap();
+
+        // Bare content on disk
+        let bare = fs::read(unpack_dir.join("parameter.txt")).unwrap();
+        assert_eq!(bare.as_slice(), content);
+
+        // --- Repack ---
+        // package-file was not in the original image, create it manually
+        fs::write(unpack_dir.join("package-file"), "parameter parameter.txt\n").unwrap();
+
+        pack_rkaf(
+            unpack_dir.to_str().unwrap(),
+            repack_file.to_str().unwrap(),
+            "RK3562",
+            "RK3562",
+        ).unwrap();
+
+        // --- Verify repacked image has PARM wrapper ---
+        let repacked = fs::read(&repack_file).unwrap();
+        let param_data = &repacked[2048..];
+        assert_eq!(&param_data[..4], b"PARM");
+        assert_eq!(&param_data[8..8 + content.len()], content);
+
+        // --- Unpack repacked image and verify content survives ---
+        fs::create_dir_all(&verify_dir).unwrap();
+        unpack_file(repack_file.to_str().unwrap(), verify_dir.to_str().unwrap()).unwrap();
+        let final_content = fs::read(verify_dir.join("parameter.txt")).unwrap();
+        assert_eq!(final_content.as_slice(), content);
     }
 }


### PR DESCRIPTION
The RKAF format wraps the "parameter" partition with an 8-byte PARM header (magic + content length) and a 4-byte RKCRC32 trailer. This matches the behaviour of the reference rkunpack.c and rkafpack.c:

- unpack: strip the PARM wrapper when extracting partitions named "parameter", writing only the bare content to disk. Detection is name-based rather than magic-based so that unpack and pack are symmetrically defined around the same condition.
- pack: re-wrap the bare content with a PARM header and RKCRC32 trailer when packing partitions named "parameter", and set part_byte_count to content_size + 12 accordingly.

Adds tests for unpack stripping, pack wrapping, and a full roundtrip.