### PR TITLE
fix: lossless RKFW/RKAF round-trip for RK3588 and >4 GiB firmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,17 +97,27 @@ additional setup is required beyond ensuring the output directory is writable.
 
 **Pack RKFW firmware:**
 ```bash
-afptool-rs pack-rkfw <input_directory> <output_file> --chip <chip> --version <version> --timestamp <unix_timestamp> --code <code_field_hex> 
+afptool-rs pack-rkfw <input_directory> <output_file> [--chip <chip>] [--version <version>] [--timestamp <unix_timestamp>] [--code <code_field_hex>]
 ```
 
-Example:
+When the input directory contains an `rkfw-header.bin` (saved automatically by
+`unpack`), the original header is used as a template and all flags become
+optional overrides — repacking unchanged content reproduces the original image
+byte-for-byte. Without a template, all four flags are required.
+
+Example (repacking an unpacked image — flags come from the saved header):
+```bash
+$ afptool-rs pack-rkfw ./out ./repacked.img
+```
+
+Example (building from scratch):
 ```bash
 $ afptool-rs pack-rkfw ./out ./repacked.img --chip RK3562 --version 1.0.0 --timestamp 1762435994 --code 0x02000000
 Successfully packed RKFW image:
   Output: ./repacked.img
   Version: 1.0.0
   Date: 2025-11-06 13:33:14
-  Chip: RK3562 (code: 0x32)
+  Chip: RK3562
   BOOT size: 469440 bytes
   Update image size: 272773124 bytes
   MD5: 9574d7cdf6f6a45bfaaad62f171fd185
@@ -118,6 +128,11 @@ Successfully packed RKFW image:
 ```bash
 afptool-rs pack-rkaf <input_directory> <output_file> --model <model> --manufacturer <manufacturer>
 ```
+
+When the input directory contains an `rkaf-header.bin` (saved automatically by
+`unpack`), it is used as a header template so vendor-specific header bytes
+survive the round-trip. Entries whose path is `RESERVED` are listed in
+`package-file` but get no header entry, matching the official tool's behavior.
 
 Example:
 ```bash

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,8 +64,8 @@ pub struct ParamHeader {
     length: u32,
 }
 
-impl UpdateHeader {
-    pub fn default() -> Self {
+impl Default for UpdateHeader {
+    fn default() -> Self {
         Self {
             magic: [0u8; 4],
             length: 0,
@@ -79,9 +79,11 @@ impl UpdateHeader {
             reserved: [0u8; 116],
         }
     }
+}
 
+impl UpdateHeader {
     pub fn from_bytes(bytes: &[u8]) -> &UpdateHeader {
-        unsafe { mem::transmute(bytes.as_ptr()) }
+        unsafe { &*(bytes.as_ptr() as *const UpdateHeader) }
     }
 
     pub fn to_bytes(&self) -> &[u8] {
@@ -89,8 +91,8 @@ impl UpdateHeader {
     }
 }
 
-impl UpdatePart {
-    pub fn default() -> Self {
+impl Default for UpdatePart {
+    fn default() -> Self {
         Self {
             name: [0u8; MAX_NAME_LEN],
             full_path: [0u8; MAX_FULL_PATH_LEN],
@@ -129,6 +131,11 @@ macro_rules! fatal {
     };
 }
 
+/// # Safety
+///
+/// The returned slice exposes the raw bytes of `p`, including any padding
+/// bytes, which may be uninitialized. Only call this on `#[repr(C, packed)]`
+/// types with no padding (such as the header structs in this crate).
 pub unsafe fn any_as_u8_slice<T: Sized>(p: &T) -> &[u8] {
     core::slice::from_raw_parts(
         (p as *const T) as *const u8,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,21 @@ use std::mem;
 mod pack;
 mod unpack;
 
-pub use pack::{pack_rkfw, pack_rkaf, chip_name_to_code};
-pub use unpack::unpack_file;
+pub use pack::{pack_rkfw, pack_rkaf, chip_name_to_code, encode_chip_field};
+pub use unpack::{unpack_file, decode_chip_field};
+
+/// Recover a true (possibly >4 GiB) length from an on-disk u32 field that
+/// only stores the low 32 bits. `available` is an upper bound derived from
+/// the actual file layout (e.g. distance to the next partition or to the end
+/// of the container); the true length is the largest value congruent to
+/// `stored` modulo 2^32 that still fits within it.
+pub fn recover_true_size(stored: u32, available: u64) -> u64 {
+    let stored = stored as u64;
+    if available <= stored {
+        return stored;
+    }
+    stored + (((available - stored) >> 32) << 32)
+}
 
 pub const RKAFP_MAGIC: &str = "RKAF";
 pub const PARM_MAGIC: &str = "PARM";
@@ -35,7 +48,7 @@ pub struct UpdateHeader {
     pub magic: [u8; 4],
     pub length: u32,
     pub model: [u8; MAX_MODEL_LEN],
-    id: [u8; MAX_ID_LEN],
+    pub id: [u8; MAX_ID_LEN],
     pub manufacturer: [u8; MAX_MANUFACTURER_LEN],
     pub unknown1: u32,
     pub version: u32,

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,17 +28,17 @@ enum Commands {
         #[arg(help = "Output RKFW firmware image file path")]
         output: String,
 
-        #[arg(short, long, help = "Chip family (e.g., RK29XX, RK30XX, RK31XX, RK32XX, RK3368, RK3326, RK3562, RK3566, PX30)")]
-        chip: String,
+        #[arg(short, long, help = "Chip name (e.g., RK3588, RK3566, RK3562, RK3399, PX30, RK32XX); optional when rkfw-header.bin from unpack is present")]
+        chip: Option<String>,
 
-        #[arg(short, long, help = "Version in format: major.minor.build (e.g., 8.1.0)")]
-        version: String,
+        #[arg(short, long, help = "Version in format: major.minor.build (e.g., 8.1.0); optional when rkfw-header.bin from unpack is present")]
+        version: Option<String>,
 
-        #[arg(short, long, help = "Unix timestamp for build date (e.g., 1731031994)")]
-        timestamp: i64,
+        #[arg(short, long, help = "Unix timestamp for build date (e.g., 1731031994); optional when rkfw-header.bin from unpack is present")]
+        timestamp: Option<i64>,
 
-        #[arg(long, help = "Code field as hex string (e.g., 0x02000000)")]
-        code: String,
+        #[arg(long, help = "Code field as hex string (e.g., 0x02000000); optional when rkfw-header.bin from unpack is present")]
+        code: Option<String>,
     },
 
     PackRkaf {
@@ -64,7 +64,7 @@ fn main() -> Result<()> {
             unpack_file(&input, &output)?;
         }
         Commands::PackRkfw{ input, output, chip, version, timestamp, code } => {
-            pack_rkfw(&input, &output, &chip, &version, timestamp, &code)?;
+            pack_rkfw(&input, &output, chip.as_deref(), version.as_deref(), timestamp, code.as_deref())?;
         }
         Commands::PackRkaf { input, output, model, manufacturer } => {
             pack_rkaf(&input, &output, &model, &manufacturer)?;

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -1,9 +1,9 @@
 use std::fs::File;
-use std::io::{Read, Write, BufRead, BufReader};
+use std::io::{Read, Write, BufRead, BufReader, BufWriter, Seek};
 use std::collections::HashMap;
 use anyhow::{anyhow, Result};
 use chrono::{Datelike, Timelike};
-use crate::{UpdateHeader, UpdatePart, MAX_NAME_LEN, MAX_FULL_PATH_LEN, RKFW_SIGNATURE, RKAF_SIGNATURE};
+use crate::{UpdateHeader, RKFW_SIGNATURE, RKAF_SIGNATURE};
 
 #[derive(Debug, Clone)]
 struct PartitionMetadata {
@@ -124,131 +124,217 @@ fn parse_partition_metadata(input_dir: &str) -> Result<HashMap<String, Partition
     Ok(metadata_map)
 }
 
-pub fn pack_rkfw(input_dir: &str, output_file: &str, chip: &str, version: &str, timestamp: i64, code_hex: &str) -> Result<()> {
-    let hex_str = code_hex.trim_start_matches("0x").trim_start_matches("0X");
-    let code_value = u32::from_str_radix(hex_str, 16)
-        .map_err(|_| anyhow!("Invalid hex value for code field: {}", hex_str))?;
-
-    let version_parts: Vec<&str> = version.split('.').collect();
-    if version_parts.len() != 3 {
-        return Err(anyhow!("Version must be in format: major.minor.build (e.g., 8.1.0)"));
-    }
-
-    let major: u8 = version_parts[0].parse()
-        .map_err(|_| anyhow!("Invalid major version"))?;
-    let minor: u8 = version_parts[1].parse()
-        .map_err(|_| anyhow!("Invalid minor version"))?;
-    let build: u16 = version_parts[2].parse()
-        .map_err(|_| anyhow!("Invalid build number"))?;
-
-    let chip_code = chip_name_to_code(chip)?;
+pub fn pack_rkfw(
+    input_dir: &str,
+    output_file: &str,
+    chip: Option<&str>,
+    version: Option<&str>,
+    timestamp: Option<i64>,
+    code_hex: Option<&str>,
+) -> Result<()> {
+    const HEADER_SIZE: usize = 0x66;
 
     let boot_path = format!("{}/BOOT", input_dir);
     let update_path = format!("{}/embedded-update.img", input_dir);
+    let template_path = format!("{}/rkfw-header.bin", input_dir);
+
+    // When repacking an unpacked image, start from the original header so
+    // undocumented fields (e.g. bytes 0x36..0x39) survive the round-trip;
+    // CLI flags act as overrides.
+    let template = match std::fs::read(&template_path) {
+        Ok(data) if data.len() >= HEADER_SIZE => Some(data),
+        _ => None,
+    };
+
+    let mut header = match &template {
+        Some(data) => data[..HEADER_SIZE].to_vec(),
+        None => vec![0u8; HEADER_SIZE],
+    };
+
+    let missing = |flag: &str| {
+        anyhow!(
+            "--{} is required because no rkfw-header.bin template was found in {}",
+            flag,
+            input_dir
+        )
+    };
+
+    header[0..4].copy_from_slice(RKFW_SIGNATURE);
+    header[0x04] = HEADER_SIZE as u8;
+
+    if let Some(version) = version {
+        let version_parts: Vec<&str> = version.split('.').collect();
+        if version_parts.len() != 3 {
+            return Err(anyhow!("Version must be in format: major.minor.build (e.g., 8.1.0)"));
+        }
+
+        let major: u8 = version_parts[0].parse()
+            .map_err(|_| anyhow!("Invalid major version"))?;
+        let minor: u8 = version_parts[1].parse()
+            .map_err(|_| anyhow!("Invalid minor version"))?;
+        let build: u16 = version_parts[2].parse()
+            .map_err(|_| anyhow!("Invalid build number"))?;
+
+        header[6] = (build & 0xFF) as u8;
+        header[7] = ((build >> 8) & 0xFF) as u8;
+        header[8] = minor;
+        header[9] = major;
+    } else if template.is_none() {
+        return Err(missing("version"));
+    }
+
+    if let Some(code_hex) = code_hex {
+        let hex_str = code_hex.trim_start_matches("0x").trim_start_matches("0X");
+        let code_value = u32::from_str_radix(hex_str, 16)
+            .map_err(|_| anyhow!("Invalid hex value for code field: {}", hex_str))?;
+        header[0x0a..0x0e].copy_from_slice(&code_value.to_le_bytes());
+    } else if template.is_none() {
+        return Err(missing("code"));
+    }
+
+    if let Some(timestamp) = timestamp {
+        let datetime = chrono::DateTime::from_timestamp(timestamp, 0)
+            .ok_or_else(|| anyhow!("Invalid timestamp"))?
+            .naive_utc();
+
+        let year = datetime.year() as u16;
+        header[0x0e] = (year & 0xFF) as u8;
+        header[0x0f] = ((year >> 8) & 0xFF) as u8;
+        header[0x10] = datetime.month() as u8;
+        header[0x11] = datetime.day() as u8;
+        header[0x12] = datetime.hour() as u8;
+        header[0x13] = datetime.minute() as u8;
+        header[0x14] = datetime.second() as u8;
+    } else if template.is_none() {
+        return Err(missing("timestamp"));
+    }
+
+    if let Some(chip) = chip {
+        header[0x15..0x19].copy_from_slice(&encode_chip_field(chip)?);
+    } else if template.is_none() {
+        return Err(missing("chip"));
+    }
+
+    if template.is_none() {
+        header[0x2d] = 0x01;
+    }
 
     let mut boot_data = Vec::new();
     File::open(&boot_path)
         .map_err(|_| anyhow!("Cannot find BOOT file in {}", input_dir))?
         .read_to_end(&mut boot_data)?;
 
-    let mut update_data = Vec::new();
-    File::open(&update_path)
-        .map_err(|_| anyhow!("Cannot find embedded-update.img file in {}", input_dir))?
-        .read_to_end(&mut update_data)?;
+    let mut update_file = File::open(&update_path)
+        .map_err(|_| anyhow!("Cannot find embedded-update.img file in {}", input_dir))?;
+    let update_size = update_file.metadata()?.len();
 
-    if update_data.len() < 4 || &update_data[0..4] != b"RKAF" {
+    let mut update_magic = [0u8; 4];
+    if update_size < 4 {
         return Err(anyhow!("embedded-update.img must be a valid RKAF file"));
     }
+    update_file.read_exact(&mut update_magic)?;
+    if &update_magic != b"RKAF" {
+        return Err(anyhow!("embedded-update.img must be a valid RKAF file"));
+    }
+    update_file.seek(std::io::SeekFrom::Start(0))?;
 
-    let header_size = 0x66;
-    let boot_offset = header_size;
-    let boot_size = boot_data.len() as u32;
+    let boot_offset = HEADER_SIZE as u64;
+    let boot_size = boot_data.len() as u64;
     let update_offset = boot_offset + boot_size;
-    let update_size = update_data.len() as u32;
 
-    let mut header = vec![0u8; header_size as usize];
-
-    header[0..4].copy_from_slice(RKFW_SIGNATURE);
-
-    header[0x04] = header_size as u8;
-
-    header[6] = (build & 0xFF) as u8;
-    header[7] = ((build >> 8) & 0xFF) as u8;
-    header[8] = minor;
-    header[9] = major;
-
-    let code_bytes = code_value.to_le_bytes();
-    header[0x0a] = code_bytes[0];
-    header[0x0b] = code_bytes[1];
-    header[0x0c] = code_bytes[2];
-    header[0x0d] = code_bytes[3];
-
-    let datetime = chrono::DateTime::from_timestamp(timestamp, 0)
-        .ok_or_else(|| anyhow!("Invalid timestamp"))?
-        .naive_utc();
-
-    let year = datetime.year() as u16;
-    let month = datetime.month() as u8;
-    let day = datetime.day() as u8;
-    let hour = datetime.hour() as u8;
-    let minute = datetime.minute() as u8;
-    let second = datetime.second() as u8;
-
-    header[0x0e] = (year & 0xFF) as u8;
-    header[0x0f] = ((year >> 8) & 0xFF) as u8;
-    header[0x10] = month;
-    header[0x11] = day;
-    header[0x12] = hour;
-    header[0x13] = minute;
-    header[0x14] = second;
-
-    header[0x15] = chip_code;
-
-    let chip_digits: Vec<u8> = chip.chars()
-        .filter(|c| c.is_numeric())
-        .map(|c| c as u8)
-        .collect();
-
-    if chip_digits.len() >= 3 {
-        header[0x16] = chip_digits[2];
-        header[0x17] = chip_digits[1];
-        header[0x18] = chip_digits[0];
+    // These offsets have no verified >4 GiB on-disk encoding; refuse rather
+    // than wrap silently. (In practice BOOT is well under 1 MiB.)
+    if boot_size > u32::MAX as u64 || update_offset > u32::MAX as u64 {
+        return Err(anyhow!("BOOT is too large ({} bytes)", boot_size));
     }
 
-    put_u32_le(&mut header[0x19..], boot_offset);
-    put_u32_le(&mut header[0x1d..], boot_size);
+    put_u32_le(&mut header[0x19..], boot_offset as u32);
+    put_u32_le(&mut header[0x1d..], boot_size as u32);
+    put_u32_le(&mut header[0x21..], update_offset as u32);
+    // The on-disk size field is 32-bit; vendor images store the low 32 bits
+    // for >4 GiB updates (verified against a real RK3588 firmware image).
+    put_u32_le(&mut header[0x25..], update_size as u32);
+    if update_size > u32::MAX as u64 {
+        println!(
+            "note: update image is {} bytes (>4 GiB); header stores the low 32 bits (0x{:08x}) as vendor images do",
+            update_size, update_size as u32
+        );
+    }
 
-    put_u32_le(&mut header[0x21..], update_offset);
-    put_u32_le(&mut header[0x25..], update_size);
+    // Stream the (potentially multi-GiB) update image through an incremental
+    // MD5 instead of concatenating everything in memory.
+    let mut md5_ctx = md5::Context::new();
+    let mut out_file = BufWriter::new(File::create(output_file)?);
 
-    // Padding
-    header[0x2d] = 0x01;
+    md5_ctx.consume(&header);
+    out_file.write_all(&header)?;
+    md5_ctx.consume(&boot_data);
+    out_file.write_all(&boot_data)?;
 
-    let mut file_data = Vec::new();
-    file_data.extend_from_slice(&header);
-    file_data.extend_from_slice(&boot_data);
-    file_data.extend_from_slice(&update_data);
+    let mut chunk = vec![0u8; 4 * 1024 * 1024];
+    loop {
+        let n = update_file.read(&mut chunk)?;
+        if n == 0 {
+            break;
+        }
+        md5_ctx.consume(&chunk[..n]);
+        out_file.write_all(&chunk[..n])?;
+    }
 
-    let digest = md5::compute(&file_data);
-    let md5_hex = format!("{:x}", digest);
-
-    let mut out_file = File::create(output_file)?;
-    out_file.write_all(&file_data)?;
+    let md5_hex = format!("{:x}", md5_ctx.finalize());
     out_file.write_all(md5_hex.as_bytes())?;
+    out_file.flush()?;
 
-    let total_size = file_data.len() + md5_hex.len();
+    let total_size = update_offset + update_size + md5_hex.len() as u64;
+    let chip_desc = chip
+        .map(str::to_string)
+        .or_else(|| crate::decode_chip_field(&header[0x15..0x19].try_into().unwrap()))
+        .unwrap_or_else(|| "from template".to_string());
 
     println!("Successfully packed RKFW image:");
     println!("  Output: {}", output_file);
-    println!("  Version: {}.{}.{}", major, minor, build);
-    println!("  Date: {}-{:02}-{:02} {:02}:{:02}:{:02}", year, month, day, hour, minute, second);
-    println!("  Chip: {} (code: 0x{:02x})", chip, chip_code);
+    println!("  Version: {}.{}.{}", header[9], header[8], ((header[7] as u16) << 8) | header[6] as u16);
+    println!(
+        "  Date: {}-{:02}-{:02} {:02}:{:02}:{:02}",
+        ((header[0x0f] as u16) << 8) | header[0x0e] as u16,
+        header[0x10], header[0x11], header[0x12], header[0x13], header[0x14]
+    );
+    println!("  Chip: {}", chip_desc);
     println!("  BOOT size: {} bytes", boot_size);
     println!("  Update image size: {} bytes", update_size);
     println!("  MD5: {}", md5_hex);
     println!("  Total size: {} bytes", total_size);
 
     Ok(())
+}
+
+/// Encode the chip identity field stored at RKFW header offsets 0x15..0x19.
+///
+/// Modern 4-digit chips (RK35xx/RK33xx/RV11xx, ...) store the four ASCII
+/// digits of the chip number in reverse byte order: a vendor RK3588 image
+/// carries '8' '8' '5' '3', which flashing tools read back as "3588". Legacy
+/// families (RK29xx/RV1108/RK30xx/RK31xx/RK32xx) predate that scheme and
+/// store a one-byte family code followed by up to three ASCII digits.
+pub fn encode_chip_field(chip: &str) -> Result<[u8; 4]> {
+    let family_code = chip_name_to_code(chip)?;
+    let digits: Vec<u8> = chip
+        .chars()
+        .filter(|c| c.is_ascii_digit())
+        .map(|c| c as u8)
+        .collect();
+
+    let legacy = matches!(family_code, 0x50 | 0x51 | 0x60 | 0x70 | 0x80);
+    if !legacy && digits.len() == 4 {
+        return Ok([digits[3], digits[2], digits[1], digits[0]]);
+    }
+
+    let mut field = [family_code, 0, 0, 0];
+    if digits.len() >= 3 {
+        field[1] = digits[2];
+        field[2] = digits[1];
+        field[3] = digits[0];
+    }
+    Ok(field)
 }
 
 pub fn chip_name_to_code(chip: &str) -> Result<u8> {
@@ -270,6 +356,18 @@ pub fn chip_name_to_code(chip: &str) -> Result<u8> {
         "RK32XX" | "RK32" | "RK3288" => Ok(0x80),
         _ => Err(anyhow!("Unsupported chip family: {}", chip)),
     }
+}
+
+/// Write a NUL-terminated string into a fixed-size header field WITHOUT
+/// zeroing the rest of the field. Vendor headers carry undocumented bytes in
+/// the tails of string fields; when packing from a saved header template
+/// those bytes must survive. Readers stop at the first NUL, so the string
+/// stays well-formed either way.
+fn write_cstr_preserving_tail(field: &mut [u8], value: &str) {
+    let bytes = value.as_bytes();
+    let len = bytes.len().min(field.len() - 1);
+    field[..len].copy_from_slice(&bytes[..len]);
+    field[len] = 0;
 }
 
 fn put_u32_le(slice: &mut [u8], value: u32) {
@@ -319,7 +417,20 @@ pub fn pack_rkaf(input_dir: &str, output_file: &str, model: &str, manufacturer: 
         }
     }
 
-    let mut header = UpdateHeader::default();
+    // When repacking an unpacked image, start from the original header so
+    // undocumented bytes (the vendor tool leaves data in the tails of string
+    // fields) survive; the fields below are overwritten with computed values.
+    let template_path = format!("{}/rkaf-header.bin", input_dir);
+    let mut header = match std::fs::read(&template_path) {
+        Ok(data) if data.len() >= std::mem::size_of::<UpdateHeader>() => {
+            *UpdateHeader::from_bytes(&data)
+        }
+        _ => {
+            let mut fresh = UpdateHeader::default();
+            fresh.version = 0x01000000;
+            fresh
+        }
+    };
     header.magic.copy_from_slice(RKAF_SIGNATURE);
 
     let model_str = if model.starts_with(' ') {
@@ -327,63 +438,56 @@ pub fn pack_rkaf(input_dir: &str, output_file: &str, model: &str, manufacturer: 
     } else {
         format!(" {}", model)
     };
-    let model_bytes = model_str.as_bytes();
-    let len = model_bytes.len().min(header.model.len() - 1);
-    header.model[..len].copy_from_slice(&model_bytes[..len]);
+    write_cstr_preserving_tail(&mut header.model, &model_str);
 
     let manufacturer_str = if manufacturer.starts_with(' ') {
         manufacturer.to_string()
     } else {
         format!(" {}", manufacturer)
     };
-    let manufacturer_bytes = manufacturer_str.as_bytes();
-    let len = manufacturer_bytes.len().min(header.manufacturer.len() - 1);
-    header.manufacturer[..len].copy_from_slice(&manufacturer_bytes[..len]);
+    write_cstr_preserving_tail(&mut header.manufacturer, &manufacturer_str);
 
     if !machine_id.is_empty() {
-        let id_bytes = format!(" {}", machine_id);
-        let id_bytes = id_bytes.as_bytes();
-        let len = id_bytes.len().min(30 - 1); // MAX_ID_LEN is 30
-        unsafe {
-            let header_ptr = &header as *const UpdateHeader as *const u8;
-            let id_offset = 42; // id field offset in UpdateHeader
-            let id_ptr = header_ptr.add(id_offset) as *mut u8;
-            std::ptr::copy_nonoverlapping(id_bytes.as_ptr(), id_ptr, len);
-        }
+        write_cstr_preserving_tail(&mut header.id, &format!(" {}", machine_id));
     }
-
-    header.num_parts = file_list.len() as u32;
-    header.version = 0x01000000; // Version
 
     let partition_metadata = parse_partition_metadata(input_dir)?;
     if partition_metadata.is_empty() {
         return Err(anyhow!("Missing partition metadata"));
     }
 
-    let header_size = std::mem::size_of::<UpdateHeader>();
-    let sector_size = 2048;
-    let mut current_offset = ((header_size + sector_size - 1) / sector_size) * sector_size;
+    let header_size = std::mem::size_of::<UpdateHeader>() as u64;
+    let sector_size: u64 = 2048;
+    let data_start = header_size.div_ceil(sector_size) * sector_size;
+    let mut current_offset = data_start;
 
-    let mut file_data_map: HashMap<String, (Vec<u8>, u32, u32)> = HashMap::new();
-    let mut file_data_list = Vec::new();
+    // Layout pass: sizes come from file metadata (or the small PARM-wrapped
+    // parameter blob built in memory); multi-GiB partitions are never loaded.
+    // (path, pre-built data for "parameter" partitions, true size, padded size)
+    let mut write_list: Vec<(String, Option<Vec<u8>>, u64, u64)> = Vec::new();
+    let mut layout_map: HashMap<String, (u64, u64)> = HashMap::new();
 
-    for (i, (name, path)) in file_list.iter().enumerate() {
-        let (file_offset, file_size, _padded_size) = if path == "SELF" || path == "RESERVED" {
-            (0, 0, 0)
-        } else if let Some((data, offset, padded)) = file_data_map.get(path) {
-            // File already loaded, reuse offset
-            (*offset, data.len() as u32, *padded)
+    let mut emitted = 0usize;
+    for (name, path) in file_list.iter() {
+        // Vendor afptool keeps RESERVED lines in package-file but does not
+        // emit a header entry for them (verified against a real RK3588 image:
+        // 10 package-file lines, num_parts = 9).
+        if path == "RESERVED" {
+            continue;
+        }
+
+        let (file_offset, file_size) = if path == "SELF" {
+            (0u64, 0u64)
+        } else if let Some(&(offset, size)) = layout_map.get(path) {
+            // File already laid out, reuse offset
+            (offset, size)
         } else {
-            // Load file for first time
             let file_path = format!("{}/{}", input_dir, path);
-            let mut raw_data = Vec::new();
-
-            File::open(&file_path)
-                .map_err(|e| anyhow!("Cannot open {}: {}", file_path, e))?
-                .read_to_end(&mut raw_data)?;
 
             // "parameter" partitions are stored PARM-wrapped in the image
-            let file_data = if name == "parameter" {
+            let (file_size, prebuilt) = if name == "parameter" {
+                let raw_data = std::fs::read(&file_path)
+                    .map_err(|e| anyhow!("Cannot open {}: {}", file_path, e))?;
                 let content_len = raw_data.len() as u32;
                 let mut wrapped = Vec::with_capacity(raw_data.len() + 12);
                 wrapped.extend_from_slice(b"PARM");
@@ -391,32 +495,35 @@ pub fn pack_rkaf(input_dir: &str, output_file: &str, model: &str, manufacturer: 
                 wrapped.extend_from_slice(&raw_data);
                 let crc = rkcrc32(0, &raw_data);
                 wrapped.extend_from_slice(&crc.to_le_bytes());
-                wrapped
+                (wrapped.len() as u64, Some(wrapped))
             } else {
-                raw_data
+                let meta = std::fs::metadata(&file_path)
+                    .map_err(|e| anyhow!("Cannot open {}: {}", file_path, e))?;
+                (meta.len(), None)
             };
 
-            let file_size = file_data.len() as u32;
-            let padded_size = ((file_size + sector_size as u32 - 1) / sector_size as u32) * sector_size as u32;
-            let file_offset = current_offset as u32;
+            let padded_size = file_size.div_ceil(sector_size) * sector_size;
+            let file_offset = current_offset;
 
-            file_data_map.insert(path.clone(), (file_data.clone(), file_offset, padded_size));
-            file_data_list.push((path.clone(), file_data));
+            layout_map.insert(path.clone(), (file_offset, file_size));
+            write_list.push((path.clone(), prebuilt, file_size, padded_size));
 
-            current_offset += padded_size as usize;
+            current_offset += padded_size;
 
-            (file_offset, file_size, padded_size)
+            (file_offset, file_size)
         };
 
-        let mut part = UpdatePart::default();
+        if emitted >= crate::MAX_PARTS {
+            return Err(anyhow!(
+                "Too many partitions in package-file (maximum is {})",
+                crate::MAX_PARTS
+            ));
+        }
 
-        let name_bytes = name.as_bytes();
-        let len = name_bytes.len().min(MAX_NAME_LEN - 1);
-        part.name[..len].copy_from_slice(&name_bytes[..len]);
-
-        let path_bytes = path.as_bytes();
-        let len = path_bytes.len().min(MAX_FULL_PATH_LEN - 1);
-        part.full_path[..len].copy_from_slice(&path_bytes[..len]);
+        // Mutate the slot in place so template bytes in the field tails survive.
+        let part = &mut header.parts[emitted];
+        write_cstr_preserving_tail(&mut part.name, name);
+        write_cstr_preserving_tail(&mut part.full_path, path);
 
         if let Some(meta) = partition_metadata.get(name) {
             part.flash_size = meta.flash_size;
@@ -430,39 +537,87 @@ pub fn pack_rkaf(input_dir: &str, output_file: &str, model: &str, manufacturer: 
             part.padded_size = 0;
         }
 
-        part.part_offset = file_offset;
-        part.part_byte_count = file_size;
+        // Data offsets beyond 4 GiB have no verified on-disk encoding; refuse
+        // rather than wrap silently. Place oversized partitions last.
+        if file_offset > u32::MAX as u64 {
+            return Err(anyhow!(
+                "partition '{}' would start at byte {} (>4 GiB); \
+                 reorder package-file so partitions larger than 4 GiB come last",
+                name, file_offset
+            ));
+        }
+        part.part_offset = file_offset as u32;
+        // The on-disk field is 32-bit; vendor images store the low 32 bits
+        // for >4 GiB partitions (verified against a real RK3588 firmware).
+        part.part_byte_count = file_size as u32;
+        if file_size > u32::MAX as u64 {
+            println!(
+                "note: partition '{}' is {} bytes (>4 GiB); header stores the low 32 bits (0x{:08x}) as vendor images do",
+                name, file_size, file_size as u32
+            );
+        }
 
-        header.parts[i] = part;
+        emitted += 1;
     }
 
+    header.num_parts = emitted as u32;
     header.length = current_offset as u32;
+    if current_offset > u32::MAX as u64 {
+        println!(
+            "note: image is {} bytes (>4 GiB); header length stores the low 32 bits (0x{:08x}) as vendor images do",
+            current_offset, current_offset as u32
+        );
+    }
 
-    let mut out_file = File::create(output_file)?;
+    // Write pass: stream every file through an incremental RockChip CRC so
+    // the image is never held in memory and never re-read for the checksum.
+    let mut out_file = BufWriter::new(File::create(output_file)?);
+    let mut checksum: u32 = 0;
+    let emit = |out: &mut BufWriter<File>, crc: &mut u32, data: &[u8]| -> Result<()> {
+        out.write_all(data)?;
+        *crc = rkcrc32(*crc, data);
+        Ok(())
+    };
 
-    out_file.write_all(header.to_bytes())?;
+    emit(&mut out_file, &mut checksum, header.to_bytes())?;
+    if data_start > header_size {
+        emit(&mut out_file, &mut checksum, &vec![0u8; (data_start - header_size) as usize])?;
+    }
 
-    let header_padding = sector_size - header_size;
-    out_file.write_all(&vec![0u8; header_padding])?;
+    let mut chunk = vec![0u8; 4 * 1024 * 1024];
+    for (path, prebuilt, file_size, padded_size) in &write_list {
+        match prebuilt {
+            Some(data) => emit(&mut out_file, &mut checksum, data)?,
+            None => {
+                let file_path = format!("{}/{}", input_dir, path);
+                let mut fp = File::open(&file_path)
+                    .map_err(|e| anyhow!("Cannot open {}: {}", file_path, e))?;
+                let mut written: u64 = 0;
+                loop {
+                    let n = fp.read(&mut chunk)?;
+                    if n == 0 {
+                        break;
+                    }
+                    emit(&mut out_file, &mut checksum, &chunk[..n])?;
+                    written += n as u64;
+                }
+                if written != *file_size {
+                    return Err(anyhow!(
+                        "{} changed size while packing ({} bytes read, {} expected)",
+                        file_path, written, file_size
+                    ));
+                }
+            }
+        }
 
-    for (path, file_data) in file_data_list.iter() {
-        out_file.write_all(file_data)?;
-
-        // Pad file
-        let (_data, _offset, padded_size) = file_data_map.get(path).unwrap();
-        let padding_size = *padded_size as usize - file_data.len();
-        if padding_size > 0 {
-            out_file.write_all(&vec![0u8; padding_size])?;
+        let padding = (padded_size - file_size) as usize;
+        if padding > 0 {
+            emit(&mut out_file, &mut checksum, &vec![0u8; padding])?;
         }
     }
 
-    let file_content = std::fs::read(output_file)?;
-    let checksum = rkcrc32(0, &file_content);
-
-    let mut out_file = std::fs::OpenOptions::new()
-        .append(true)
-        .open(output_file)?;
     out_file.write_all(&checksum.to_le_bytes())?;
+    out_file.flush()?;
 
     let num_parts = header.num_parts;
 

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -9,7 +9,6 @@ use crate::{UpdateHeader, RKFW_SIGNATURE, RKAF_SIGNATURE};
 struct PartitionMetadata {
     flash_size: u32,
     flash_offset: u32,
-    padded_size: u32,
 }
 
 // RockChip CRC-32 table
@@ -111,12 +110,10 @@ fn parse_partition_metadata(input_dir: &str) -> Result<HashMap<String, Partition
             let name = parts[0].to_string();
             let flash_size = u32::from_str_radix(parts[2].trim_start_matches("0x"), 16)?;
             let flash_offset = u32::from_str_radix(parts[3].trim_start_matches("0x"), 16)?;
-            let padded_size = u32::from_str_radix(parts[5].trim_start_matches("0x"), 16)?;
 
             metadata_map.insert(name, PartitionMetadata {
                 flash_size,
                 flash_offset,
-                padded_size,
             });
         }
     }
@@ -528,14 +525,19 @@ pub fn pack_rkaf(input_dir: &str, output_file: &str, model: &str, manufacturer: 
         if let Some(meta) = partition_metadata.get(name) {
             part.flash_size = meta.flash_size;
             part.flash_offset = meta.flash_offset;
-            part.padded_size = meta.padded_size;
         } else {
             // Instead of returning an error, assume it's a special partition
             // with no data and use default values.
             part.flash_size = 0;
             part.flash_offset = 0;
-            part.padded_size = 0;
         }
+
+        // padded_size is in 2048-byte sectors and encodes the TRUE length
+        // (the vendor's 4.5 GiB userdata stores 0x240000 sectors while
+        // part_byte_count wraps at 4 GiB). Compute it from the file actually
+        // being packed — metadata from a previous unpack goes stale as soon
+        // as a partition is swapped for one of a different size.
+        part.padded_size = file_size.div_ceil(sector_size) as u32;
 
         // Data offsets beyond 4 GiB have no verified on-disk encoding; refuse
         // rather than wrap silently. Place oversized partitions last.

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -404,12 +404,10 @@ pub fn pack_rkaf(input_dir: &str, output_file: &str, model: &str, manufacturer: 
     let mut machine_id = String::new();
     if let Ok(param_file) = File::open(format!("{}/parameter.txt", input_dir)) {
         let reader = BufReader::new(param_file);
-        for line in reader.lines() {
-            if let Ok(line) = line {
-                if line.starts_with("MACHINE_ID:") {
-                    machine_id = line.split(':').nth(1).unwrap_or("").trim().to_string();
-                    break;
-                }
+        for line in reader.lines().map_while(Result::ok) {
+            if line.starts_with("MACHINE_ID:") {
+                machine_id = line.split(':').nth(1).unwrap_or("").trim().to_string();
+                break;
             }
         }
     }
@@ -422,11 +420,10 @@ pub fn pack_rkaf(input_dir: &str, output_file: &str, model: &str, manufacturer: 
         Ok(data) if data.len() >= std::mem::size_of::<UpdateHeader>() => {
             *UpdateHeader::from_bytes(&data)
         }
-        _ => {
-            let mut fresh = UpdateHeader::default();
-            fresh.version = 0x01000000;
-            fresh
-        }
+        _ => UpdateHeader {
+            version: 0x01000000,
+            ..Default::default()
+        },
     };
     header.magic.copy_from_slice(RKAF_SIGNATURE);
 
@@ -446,6 +443,11 @@ pub fn pack_rkaf(input_dir: &str, output_file: &str, model: &str, manufacturer: 
 
     if !machine_id.is_empty() {
         write_cstr_preserving_tail(&mut header.id, &format!(" {}", machine_id));
+    } else {
+        // No MACHINE_ID in parameter.txt: clear the logical id so a template
+        // value cannot leak through. Bytes after the NUL are left untouched
+        // for vendor-tail fidelity; readers stop at the first NUL.
+        header.id[0] = 0;
     }
 
     let partition_metadata = parse_partition_metadata(input_dir)?;

--- a/src/unpack.rs
+++ b/src/unpack.rs
@@ -116,7 +116,7 @@ fn unpack_rkfw(file_path: &str, dst_path: &str) -> Result<()> {
 
     // Keep the original header so pack-rkfw can use it as a template and
     // preserve fields that are otherwise lost (timestamp, code, unknown bytes).
-    write_file(&Path::new(&format!("{}/rkfw-header.bin", dst_path)), &buf)?;
+    write_file(Path::new(&format!("{}/rkfw-header.bin", dst_path)), &buf)?;
 
     let ioff = get_u32_le(&buf[0x19..]) as u64;
     let isize = get_u32_le(&buf[0x1d..]) as u64;
@@ -268,7 +268,7 @@ fn unpack_rkafp(file_path: &str, dst_path: &str) -> Result<()> {
     // Keep the original header so pack-rkaf can use it as a template and
     // preserve undocumented bytes (the vendor tool leaves data in the tails
     // of string fields).
-    write_file(&Path::new(&format!("{}/rkaf-header.bin", dst_path)), &buf)?;
+    write_file(Path::new(&format!("{}/rkaf-header.bin", dst_path)), &buf)?;
 
     // Save partition metadata for repacking
     let metadata_path = format!("{}/partition-metadata.txt", dst_path);
@@ -295,7 +295,7 @@ fn unpack_rkafp(file_path: &str, dst_path: &str) -> Result<()> {
                 metadata_file,
                 "{},{},{:#010x},{:#010x},{:#010x},{:#010x},{:#010x}",
                 part_name,
-                &part_full_path,
+                part_full_path,
                 flash_size,
                 flash_offset,
                 part_offset,

--- a/src/unpack.rs
+++ b/src/unpack.rs
@@ -7,13 +7,12 @@ use crate::{RKAF_SIGNATURE, RKFW_SIGNATURE, UpdateHeader, RKAFP_MAGIC};
 
 pub fn unpack_file(file_path: &str, dst_path: &str) -> Result<()> {
     let mut file = File::open(file_path)?;
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer)?;
+    let mut signature = [0u8; 4];
+    file.read_exact(&mut signature)?;
 
-    let signature = &buffer[0..4];
-    match signature {
+    match &signature[..] {
         RKAF_SIGNATURE => unpack_rkafp(file_path, dst_path)?,
-        RKFW_SIGNATURE => unpack_rkfw(&buffer, dst_path)?,
+        RKFW_SIGNATURE => unpack_rkfw(file_path, dst_path)?,
         _ => {
             return Err(anyhow!("Unknown signature: {:?}", signature));
         }
@@ -21,7 +20,27 @@ pub fn unpack_file(file_path: &str, dst_path: &str) -> Result<()> {
     Ok(())
 }
 
-fn unpack_rkfw(buf: &[u8], dst_path: &str) -> Result<()> {
+/// Decode the modern chip identity field at RKFW offsets 0x15..0x19: the four
+/// ASCII digits of the chip number stored last-digit-first (a vendor RK3588
+/// image carries '8' '8' '5' '3'). Returns None for legacy one-byte
+/// family-code encodings, which are resolved via the family table instead.
+pub fn decode_chip_field(field: &[u8; 4]) -> Option<String> {
+    if field.iter().all(|b| b.is_ascii_digit()) {
+        let digits: String = field.iter().rev().map(|&b| b as char).collect();
+        Some(format!("RK{}", digits))
+    } else {
+        None
+    }
+}
+
+fn unpack_rkfw(file_path: &str, dst_path: &str) -> Result<()> {
+    const HEADER_SIZE: usize = 0x66;
+
+    let mut fp = File::open(file_path)?;
+    let filesize = fp.metadata()?.len();
+    let mut buf = [0u8; HEADER_SIZE];
+    fp.read_exact(&mut buf)?;
+
     let mut chip: Option<&str> = None;
 
     println!("RKFW signature detected");
@@ -44,49 +63,63 @@ fn unpack_rkfw(buf: &[u8], dst_path: &str) -> Result<()> {
     let minute = buf[0x13];
     let second = buf[0x14];
 
-    let date = chrono::NaiveDate::from_ymd_opt(year as i32, month as u32, day as u32)
-        .ok_or_else(|| anyhow!("Invalid date"))?;
-    let time = chrono::NaiveTime::from_hms_opt(hour as u32, minute as u32, second as u32)
-        .ok_or_else(|| anyhow!("Invalid time"))?;
-    let dt = NaiveDateTime::new(date, time);
-    let unix_timestamp = dt.and_utc().timestamp();
-
-    println!(
-        "date: {}-{:02}-{:02} {:02}:{:02}:{:02} (Unix timestamp: {})",
-        year, month, day, hour, minute, second, unix_timestamp
-    );
-
-    match buf[0x15] {
-        0x19 => chip = Some("RV1109/RV1126"),
-        0x30 => chip = Some("PX30/RK3326"),
-        0x32 => chip = Some("RK3562"),
-        0x33 => chip = Some("RK3399/RK3399Pro"),
-        0x35 => chip = Some("RK3588/RK3588S"),
-        0x36 => chip = Some("RK3326"),
-        0x38 => chip = Some("RK3566/RK3568"),
-        0x39 => chip = Some("RK3528"),
-        0x41 => chip = Some("RK3368"),
-        0x48 => chip = Some("RK3308"),
-        0x50 => chip = Some("RK29xx"),
-        0x51 => chip = Some("RV1108"),
-        0x60 => chip = Some("RK30xx/RK3066"),
-        0x70 => chip = Some("RK31xx/RK3188"),
-        0x80 => chip = Some("RK32xx/RK3288"),
+    // The date is informational only; a malformed field must not stop extraction.
+    let date = chrono::NaiveDate::from_ymd_opt(year as i32, month as u32, day as u32);
+    let time = chrono::NaiveTime::from_hms_opt(hour as u32, minute as u32, second as u32);
+    match (date, time) {
+        (Some(date), Some(time)) => {
+            let unix_timestamp = NaiveDateTime::new(date, time).and_utc().timestamp();
+            println!(
+                "date: {}-{:02}-{:02} {:02}:{:02}:{:02} (Unix timestamp: {})",
+                year, month, day, hour, minute, second, unix_timestamp
+            );
+        }
         _ => println!(
-            "You got a brand new chip ({:#x}), congratulations!!!",
-            buf[0x15]
+            "date: {}-{:02}-{:02} {:02}:{:02}:{:02} (invalid)",
+            year, month, day, hour, minute, second
         ),
     }
 
-    let chip_name = chip.unwrap_or("unknown");
+    // Modern images carry the chip number as four ASCII digits; legacy images
+    // carry a one-byte family code at 0x15.
+    let chip_field: [u8; 4] = buf[0x15..0x19].try_into().unwrap();
+    let decoded_chip = decode_chip_field(&chip_field);
+
+    if decoded_chip.is_none() {
+        match buf[0x15] {
+            0x19 => chip = Some("RV1109/RV1126"),
+            0x30 => chip = Some("PX30/RK3326"),
+            0x32 => chip = Some("RK3562"),
+            0x33 => chip = Some("RK3399/RK3399Pro"),
+            0x35 => chip = Some("RK3588/RK3588S"),
+            0x36 => chip = Some("RK3326"),
+            0x38 => chip = Some("RK3566/RK3568"),
+            0x39 => chip = Some("RK3528"),
+            0x41 => chip = Some("RK3368"),
+            0x48 => chip = Some("RK3308"),
+            0x50 => chip = Some("RK29xx"),
+            0x51 => chip = Some("RV1108"),
+            0x60 => chip = Some("RK30xx/RK3066"),
+            0x70 => chip = Some("RK31xx/RK3188"),
+            0x80 => chip = Some("RK32xx/RK3288"),
+            _ => println!(
+                "You got a brand new chip ({:#x}), congratulations!!!",
+                buf[0x15]
+            ),
+        }
+    }
+
+    let chip_name = decoded_chip.as_deref().or(chip).unwrap_or("unknown");
     println!("family: {}", chip_name);
 
-    let ioff = get_u32_le(&buf[0x19..]);
-    let isize: u32 = get_u32_le(&buf[0x1d..]);
+    std::fs::create_dir_all(dst_path)?;
 
-    // if &buf[ioff as usize..ioff as usize + 4] != b"BOOT" {
-    //     panic!("cannot find BOOT signature");
-    // }
+    // Keep the original header so pack-rkfw can use it as a template and
+    // preserve fields that are otherwise lost (timestamp, code, unknown bytes).
+    write_file(&Path::new(&format!("{}/rkfw-header.bin", dst_path)), &buf)?;
+
+    let ioff = get_u32_le(&buf[0x19..]) as u64;
+    let isize = get_u32_le(&buf[0x1d..]) as u64;
 
     println!(
         "{:08x}-{:08x} {:26} (size: {})",
@@ -95,17 +128,36 @@ fn unpack_rkfw(buf: &[u8], dst_path: &str) -> Result<()> {
         "BOOT",
         isize
     );
-    std::fs::create_dir_all(dst_path)?;
-    write_file(
-        &Path::new(&format!("{}/BOOT", dst_path)),
-        &buf[ioff as usize..ioff as usize + (isize as usize)],
-    )?;
+    extract_file(&mut fp, ioff, isize, &format!("{}/BOOT", dst_path))?;
 
-    let ioff = get_u32_le(&buf[0x21..]);
-    let isize = get_u32_le(&buf[0x25..]);
+    let ioff = get_u32_le(&buf[0x21..]) as u64;
+    let stored_size = get_u32_le(&buf[0x25..]);
 
-    if &buf[ioff as usize..ioff as usize + 4] != b"RKAF" {
-        panic!("cannot find embedded RKAF update.img");
+    let mut magic = [0u8; 4];
+    fp.seek(std::io::SeekFrom::Start(ioff))?;
+    fp.read_exact(&mut magic)?;
+    if &magic != b"RKAF" {
+        return Err(anyhow!("cannot find embedded RKAF update.img"));
+    }
+
+    // The size field only holds the low 32 bits for >4 GiB updates, so derive
+    // the true size from the file layout: everything between the update offset
+    // and the trailing 32-char ASCII MD5 belongs to the update image.
+    let mut data_end = filesize;
+    if filesize >= ioff + 32 {
+        let mut tail = [0u8; 32];
+        fp.seek(std::io::SeekFrom::End(-32))?;
+        fp.read_exact(&mut tail)?;
+        if tail.iter().all(u8::is_ascii_hexdigit) {
+            data_end = filesize - 32;
+        }
+    }
+    let isize = crate::recover_true_size(stored_size, data_end.saturating_sub(ioff));
+    if isize != stored_size as u64 {
+        println!(
+            "note: header size field is 0x{:08x}; recovered true update size {} bytes (>4 GiB, field wrapped)",
+            stored_size, isize
+        );
     }
 
     println!(
@@ -115,16 +167,13 @@ fn unpack_rkfw(buf: &[u8], dst_path: &str) -> Result<()> {
         "embedded-update.img",
         isize
     );
-    write_file(
-        &Path::new(&format!("{}/embedded-update.img", dst_path)),
-        &buf[ioff as usize..ioff as usize + isize as usize],
-    )?;
+    extract_file(&mut fp, ioff, isize, &format!("{}/embedded-update.img", dst_path))?;
     Ok(())
 }
 
 fn extract_file(fp: &mut File, offset: u64, len: u64, full_path: &str) -> Result<()> {
     println!("{:08x}-{:08x} {}", offset, len, full_path);
-    let mut buffer = vec![0u8; 16 * 1024];
+    let mut buffer = vec![0u8; 4 * 1024 * 1024];
     let mut fp_out = File::create(full_path)?;
 
     fp.seek(std::io::SeekFrom::Start(offset))?;
@@ -168,7 +217,7 @@ fn unpack_rkafp(file_path: &str, dst_path: &str) -> Result<()> {
     let mut fp = File::open(file_path)?;
     let mut buf = vec![0u8; mem::size_of::<UpdateHeader>()];
     fp.read_exact(&mut buf)?;
-    let header = UpdateHeader::from_bytes(buf.as_mut());
+    let header = UpdateHeader::from_bytes(&buf);
     let magic_str = std::str::from_utf8(&header.magic)?;
     if magic_str != RKAFP_MAGIC {
         return Err(anyhow!("Invalid header magic id"));
@@ -176,9 +225,34 @@ fn unpack_rkafp(file_path: &str, dst_path: &str) -> Result<()> {
 
     let filesize = fp.metadata()?.len();
     println!("Filesize: {}", filesize);
-    if filesize - 4 != header.length as u64 {
-        eprintln!("update_header.length cannot be correct, cannot check CRC");
+
+    if header.num_parts as usize > crate::MAX_PARTS {
+        return Err(anyhow!(
+            "Corrupt header: {} partitions (maximum is {})",
+            header.num_parts as u32,
+            crate::MAX_PARTS
+        ));
     }
+
+    // The length field only stores the low 32 bits, so compare modulo 2^32.
+    let container_end = filesize.saturating_sub(4); // trailing CRC
+    if (container_end as u32) != header.length {
+        eprintln!("update_header.length cannot be correct, cannot check CRC");
+    } else if container_end > u32::MAX as u64 {
+        println!(
+            "note: container is {} bytes (>4 GiB); header length field holds the low 32 bits",
+            container_end
+        );
+    }
+
+    // Offsets of all data-bearing partitions, used to bound each partition's
+    // true size when its 32-bit byte count has wrapped.
+    let mut data_offsets: Vec<u64> = (0..header.num_parts as usize)
+        .map(|i| header.parts[i].part_offset as u64)
+        .filter(|&off| off > 0)
+        .collect();
+    data_offsets.sort_unstable();
+    data_offsets.dedup();
     std::fs::create_dir_all(format!("{}/Image", dst_path))?;
     // 安全地从null-terminated字符串中提取文本
     let manufacturer = std::ffi::CStr::from_bytes_until_nul(&header.manufacturer)
@@ -190,6 +264,11 @@ fn unpack_rkafp(file_path: &str, dst_path: &str) -> Result<()> {
 
     println!("manufacturer: {}", manufacturer);
     println!("model: {}", model);
+
+    // Keep the original header so pack-rkaf can use it as a template and
+    // preserve undocumented bytes (the vendor tool leaves data in the tails
+    // of string fields).
+    write_file(&Path::new(&format!("{}/rkaf-header.bin", dst_path)), &buf)?;
 
     // Save partition metadata for repacking
     let metadata_path = format!("{}/partition-metadata.txt", dst_path);
@@ -229,12 +308,29 @@ fn unpack_rkafp(file_path: &str, dst_path: &str) -> Result<()> {
             }
 
             let file_to_extract = format!("{}/{}", dst_path, part_full_path);
-            let (data_offset, data_len) = parm_content_range(
-                &part_name,
-                &mut fp,
-                part.part_offset as u64,
-                part.part_byte_count as u64,
-            )?;
+
+            // part_byte_count only stores the low 32 bits; recover the true
+            // size using the next partition's offset (or the container end)
+            // as an upper bound.
+            let offset = part.part_offset as u64;
+            let bound = data_offsets
+                .iter()
+                .find(|&&o| o > offset)
+                .copied()
+                .unwrap_or(container_end);
+            let true_count = crate::recover_true_size(
+                part.part_byte_count,
+                bound.saturating_sub(offset),
+            );
+            if true_count != part.part_byte_count as u64 {
+                println!(
+                    "note: partition '{}' byte count field is 0x{:08x}; recovered true size {} bytes (>4 GiB, field wrapped)",
+                    part_name, part_byte_count, true_count
+                );
+            }
+
+            let (data_offset, data_len) =
+                parm_content_range(&part_name, &mut fp, offset, true_count)?;
             extract_file(&mut fp, data_offset, data_len, &file_to_extract)?;
         }
     }

--- a/tests/advanced_tests.rs
+++ b/tests/advanced_tests.rs
@@ -133,9 +133,10 @@ mod advanced_tests {
         
         // 运行命令
         let mut cmd = Command::cargo_bin("afptool-rs")?;
-        cmd.arg(input_file.to_str().unwrap())
+        cmd.arg("unpack")
+           .arg(input_file.to_str().unwrap())
            .arg(output_dir.to_str().unwrap());
-        
+
         cmd.assert()
            .success()
            .stdout(predicate::str::contains("RKFW signature detected"))
@@ -163,9 +164,10 @@ mod advanced_tests {
         
         // 运行命令
         let mut cmd = Command::cargo_bin("afptool-rs")?;
-        cmd.arg(input_file.to_str().unwrap())
+        cmd.arg("unpack")
+           .arg(input_file.to_str().unwrap())
            .arg(output_dir.to_str().unwrap());
-        
+
         // 执行命令并检查输出
         cmd.assert()
            .success()
@@ -192,9 +194,10 @@ mod advanced_tests {
         
         // 运行命令
         let mut cmd = Command::cargo_bin("afptool-rs").unwrap();
-        cmd.arg(input_file.to_str().unwrap())
+        cmd.arg("unpack")
+           .arg(input_file.to_str().unwrap())
            .arg(output_dir.to_str().unwrap());
-        
+
         // 应该失败并输出错误信息
         cmd.assert()
            .failure()

--- a/tests/bugfix_tests.rs
+++ b/tests/bugfix_tests.rs
@@ -336,6 +336,35 @@ mod tests {
         assert_eq!(&img[140 + 112..140 + 112 + 9], b"userdata\0");
     }
 
+    /// padded_size is stored in 2048-byte sectors and encodes the TRUE
+    /// partition length (the vendor's 4.5 GiB userdata carries 0x240000
+    /// sectors while part_byte_count wraps). It must be computed from the
+    /// actual file being packed — not copied from partition-metadata.txt,
+    /// which goes stale the moment a partition is swapped for one of a
+    /// different size.
+    #[test]
+    fn rkaf_padded_size_computed_from_actual_file_not_stale_metadata() {
+        let dir = TempDir::new().unwrap();
+        let input = dir.path();
+        // 5000 bytes -> ceil(5000/2048) = 3 sectors
+        fs::write(input.join("userdata.img"), vec![0xAAu8; 5000]).unwrap();
+        fs::write(input.join("package-file"), "userdata userdata.img\n").unwrap();
+        // metadata claims 1 sector (stale: recorded when the partition was smaller)
+        fs::write(
+            input.join("partition-metadata.txt"),
+            "userdata,userdata.img,0xffffffff,0x00a98000,0x00000800,0x00000001,0x00000400\n",
+        )
+        .unwrap();
+
+        let out = dir.path().join("out.rkaf");
+        pack_rkaf(input.to_str().unwrap(), out.to_str().unwrap(), "RK3588", "RK3588").unwrap();
+
+        let img = fs::read(&out).unwrap();
+        // part 0 numeric fields start at 140 + 92; padded_size is the 4th u32
+        let padded = u32::from_le_bytes(img[140 + 92 + 12..140 + 92 + 16].try_into().unwrap());
+        assert_eq!(padded, 3, "padded_size must reflect the actual file (3 sectors), not stale metadata");
+    }
+
     // ---------------- Bug 2 end-to-end: 5 GiB member round-trip ----------------
     // Expensive (~11 GB of temp disk I/O); run with: cargo test -- --ignored
 

--- a/tests/bugfix_tests.rs
+++ b/tests/bugfix_tests.rs
@@ -1,0 +1,402 @@
+// Regression tests for the RK3588 firmware round-trip failures:
+//   Bug 1 - chip identity mis-encoded for 4-digit chips (Check Chip Fail)
+//   Bug 2 - u32 size/offset wrapping for >4 GiB content (silent truncation)
+//   Bug 3 - RKFW header fields not preserved on round-trip
+#[cfg(test)]
+mod tests {
+    use std::fs::{self, File};
+    use std::io::{Seek, SeekFrom, Write};
+    use afptool_rs::{
+        decode_chip_field, encode_chip_field, pack_rkaf, pack_rkfw, recover_true_size,
+        unpack_file,
+    };
+    use tempfile::TempDir;
+
+    // ---------------- Bug 1: chip field encoding ----------------
+
+    #[test]
+    fn chip_field_rk3588_is_ascii_digits_reversed() {
+        // Verified by hexdump of a vendor RK3588 image: 0x15..0x19 = '8' '8' '5' '3'
+        assert_eq!(encode_chip_field("RK3588").unwrap(), [b'8', b'8', b'5', b'3']);
+        assert_eq!(encode_chip_field("RK3588S").unwrap(), [b'8', b'8', b'5', b'3']);
+    }
+
+    #[test]
+    fn chip_field_rk3562_matches_previous_encoding() {
+        // Coincidence case: family code 0x32 == ASCII '2'. The README's chip must
+        // round-trip identically after the fix.
+        assert_eq!(encode_chip_field("RK3562").unwrap(), [0x32, b'6', b'5', b'3']);
+    }
+
+    #[test]
+    fn chip_field_legacy_families_keep_family_code() {
+        // Legacy chips predate the ASCII scheme; behavior must not change.
+        assert_eq!(encode_chip_field("RK3288").unwrap(), [0x80, b'8', b'2', b'3']);
+        assert_eq!(encode_chip_field("RK3066").unwrap(), [0x60, b'6', b'0', b'3']);
+        assert_eq!(encode_chip_field("RK29XX").unwrap(), [0x50, 0, 0, 0]);
+        assert_eq!(encode_chip_field("PX30").unwrap(), [0x30, 0, 0, 0]);
+    }
+
+    #[test]
+    fn chip_field_decode() {
+        assert_eq!(decode_chip_field(&[b'8', b'8', b'5', b'3']), Some("RK3588".to_string()));
+        assert_eq!(decode_chip_field(&[0x32, b'6', b'5', b'3']), Some("RK3562".to_string()));
+        // Legacy family byte with zero padding is not an ASCII-digit field
+        assert_eq!(decode_chip_field(&[0x30, 0, 0, 0]), None);
+        assert_eq!(decode_chip_field(&[0x80, b'8', b'2', b'3']), None);
+    }
+
+    // ---------------- Bug 2: >4 GiB size recovery ----------------
+
+    #[test]
+    fn recover_true_size_no_wrap() {
+        // Small partition: stored value is already the truth
+        assert_eq!(recover_true_size(0x20, 906), 0x20);
+        // Bound smaller than stored (corrupt input): trust the stored value
+        assert_eq!(recover_true_size(100, 50), 100);
+    }
+
+    #[test]
+    fn recover_true_size_userdata_from_real_firmware() {
+        // Real numbers from the RK3588 vendor image: 4.5 GiB userdata whose
+        // part_byte_count wrapped to exactly 512 MiB.
+        assert_eq!(recover_true_size(536_870_912, 4_831_838_208), 4_831_838_208);
+        // Same, with sector-padding slack above the true size
+        assert_eq!(recover_true_size(536_870_912, 4_831_840_000), 4_831_838_208);
+    }
+
+    #[test]
+    fn recover_true_size_rkfw_update_from_real_firmware() {
+        // RKFW header stored 0xED85D004; true embedded update size is 8,279,937,028
+        assert_eq!(recover_true_size(0xED85D004, 8_279_937_028), 8_279_937_028);
+    }
+
+    // ---------------- helpers ----------------
+
+    /// Builds a minimal but complete RKFW image byte-for-byte, including the
+    /// trailing 32-char ASCII MD5, with the vendor-observed unknown bytes at
+    /// 0x36..0x39 so header fidelity can be asserted.
+    fn build_reference_rkfw(boot: &[u8], update: &[u8]) -> Vec<u8> {
+        let mut h = vec![0u8; 0x66];
+        h[0..4].copy_from_slice(b"RKFW");
+        h[0x04] = 0x66;
+        // version 8.1.1
+        h[6] = 0x01;
+        h[8] = 0x01;
+        h[9] = 0x08;
+        // code 0x02000000 (LE)
+        h[0x0d] = 0x02;
+        // date 2026-04-29 23:04:41
+        h[0x0e] = 0xea;
+        h[0x0f] = 0x07;
+        h[0x10] = 4;
+        h[0x11] = 29;
+        h[0x12] = 23;
+        h[0x13] = 4;
+        h[0x14] = 41;
+        // chip RK3588 as ASCII digits reversed
+        h[0x15..0x19].copy_from_slice(&[b'8', b'8', b'5', b'3']);
+        // BOOT offset/size
+        h[0x19..0x1d].copy_from_slice(&(0x66u32).to_le_bytes());
+        h[0x1d..0x21].copy_from_slice(&(boot.len() as u32).to_le_bytes());
+        // update offset/size
+        h[0x21..0x25].copy_from_slice(&((0x66 + boot.len()) as u32).to_le_bytes());
+        h[0x25..0x29].copy_from_slice(&(update.len() as u32).to_le_bytes());
+        h[0x2d] = 0x01;
+        // unknown-but-observed vendor bytes that must be preserved
+        h[0x36..0x39].copy_from_slice(&[0x48, 0x49, 0x01]);
+
+        let mut body = h;
+        body.extend_from_slice(boot);
+        body.extend_from_slice(update);
+        let md5_hex = format!("{:x}", md5::compute(&body));
+        body.extend_from_slice(md5_hex.as_bytes());
+        body
+    }
+
+    fn mock_update_img() -> Vec<u8> {
+        let mut update = b"RKAF".to_vec();
+        update.extend_from_slice(&[0xAB; 28]);
+        update
+    }
+
+    // ---------------- Bug 1 end-to-end: pack writes correct chip bytes ----------------
+
+    #[test]
+    fn rkfw_pack_writes_rk3588_chip_bytes() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("BOOT"), b"BOOTDATA12345678").unwrap();
+        fs::write(dir.path().join("embedded-update.img"), mock_update_img()).unwrap();
+        let out = dir.path().join("out.img");
+
+        pack_rkfw(
+            dir.path().to_str().unwrap(),
+            out.to_str().unwrap(),
+            Some("RK3588"),
+            Some("1.0.0"),
+            Some(1731031994),
+            Some("0x02000000"),
+        )
+        .unwrap();
+
+        let img = fs::read(&out).unwrap();
+        assert_eq!(
+            &img[0x15..0x19],
+            &[b'8', b'8', b'5', b'3'],
+            "chip field must be the four ASCII digits reversed (reads back as 3588)"
+        );
+    }
+
+    // ---------------- Bug 3: header template preserved on round-trip ----------------
+
+    #[test]
+    fn rkfw_roundtrip_is_byte_identical_with_saved_header() {
+        let boot = b"BOOTDATA12345678";
+        let update = mock_update_img();
+        let original = build_reference_rkfw(boot, &update);
+
+        let dir = TempDir::new().unwrap();
+        let src = dir.path().join("original.img");
+        let unpacked = dir.path().join("unpacked");
+        fs::write(&src, &original).unwrap();
+
+        unpack_file(src.to_str().unwrap(), unpacked.to_str().unwrap()).unwrap();
+
+        // unpack must persist the original header for later repacking
+        let saved_header = fs::read(unpacked.join("rkfw-header.bin")).unwrap();
+        assert_eq!(&saved_header[..], &original[..0x66]);
+        assert_eq!(fs::read(unpacked.join("BOOT")).unwrap(), boot);
+        assert_eq!(fs::read(unpacked.join("embedded-update.img")).unwrap(), update);
+
+        // Repack with no CLI overrides: everything comes from the template
+        let rebuilt_path = dir.path().join("rebuilt.img");
+        pack_rkfw(
+            unpacked.to_str().unwrap(),
+            rebuilt_path.to_str().unwrap(),
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+        let rebuilt = fs::read(&rebuilt_path).unwrap();
+        assert_eq!(
+            rebuilt, original,
+            "unchanged content must repack to a byte-identical image"
+        );
+    }
+
+    #[test]
+    fn rkfw_pack_cli_flags_override_template() {
+        let boot = b"BOOTDATA12345678";
+        let update = mock_update_img();
+        let original = build_reference_rkfw(boot, &update);
+
+        let dir = TempDir::new().unwrap();
+        let src = dir.path().join("original.img");
+        let unpacked = dir.path().join("unpacked");
+        fs::write(&src, &original).unwrap();
+        unpack_file(src.to_str().unwrap(), unpacked.to_str().unwrap()).unwrap();
+
+        let rebuilt_path = dir.path().join("rebuilt.img");
+        pack_rkfw(
+            unpacked.to_str().unwrap(),
+            rebuilt_path.to_str().unwrap(),
+            None,
+            Some("2.3.4"),
+            None,
+            None,
+        )
+        .unwrap();
+
+        let rebuilt = fs::read(&rebuilt_path).unwrap();
+        assert_eq!(rebuilt[9], 2, "major version overridden");
+        assert_eq!(rebuilt[8], 3, "minor version overridden");
+        assert_eq!(rebuilt[6], 4, "build overridden");
+        // untouched template fields survive
+        assert_eq!(&rebuilt[0x36..0x39], &[0x48, 0x49, 0x01]);
+        assert_eq!(&rebuilt[0x15..0x19], &[b'8', b'8', b'5', b'3']);
+    }
+
+    #[test]
+    fn rkfw_pack_without_template_requires_flags() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("BOOT"), b"BOOTDATA12345678").unwrap();
+        fs::write(dir.path().join("embedded-update.img"), mock_update_img()).unwrap();
+        let out = dir.path().join("out.img");
+
+        let result = pack_rkfw(
+            dir.path().to_str().unwrap(),
+            out.to_str().unwrap(),
+            None,
+            Some("1.0.0"),
+            Some(1731031994),
+            Some("0x02000000"),
+        );
+        assert!(result.is_err(), "--chip is required when no rkfw-header.bin exists");
+    }
+
+    // ---------------- RKAF header fidelity (device did not boot) ----------------
+
+    /// Vendor afptool drops RESERVED package-file lines from the header: the
+    /// real RK3588 image lists "backup RESERVED" in package-file but its
+    /// header has num_parts=9, not 10. A phantom all-zero entry must not be
+    /// emitted.
+    #[test]
+    fn rkaf_reserved_entries_are_dropped_from_header() {
+        let dir = TempDir::new().unwrap();
+        let input = dir.path();
+        fs::write(input.join("parameter.txt"), b"CMDLINE:x\n").unwrap();
+        fs::write(input.join("userdata.img"), vec![0xAAu8; 100]).unwrap();
+        fs::write(
+            input.join("package-file"),
+            "parameter parameter.txt\nbackup RESERVED\nuserdata userdata.img\n",
+        )
+        .unwrap();
+        fs::write(
+            input.join("partition-metadata.txt"),
+            "parameter,parameter.txt,0x00004000,0x00000000,0x00000800,0x00000001,0x00000016\n\
+             userdata,userdata.img,0xffffffff,0x00a98000,0x00001000,0x00000001,0x00000064\n",
+        )
+        .unwrap();
+
+        let out = dir.path().join("out.rkaf");
+        pack_rkaf(input.to_str().unwrap(), out.to_str().unwrap(), "RK3588", "RK3588").unwrap();
+
+        let img = fs::read(&out).unwrap();
+        let num_parts = u32::from_le_bytes(img[136..140].try_into().unwrap());
+        assert_eq!(num_parts, 2, "RESERVED entry must not be counted");
+
+        // part slot 1 (140 + 112) must be userdata, not the phantom backup
+        let name1 = &img[140 + 112..140 + 112 + 8];
+        assert_eq!(name1, b"userdata");
+        assert!(
+            !img[..2048].windows(8).any(|w| w == b"RESERVED"),
+            "no RESERVED entry may appear in the header"
+        );
+    }
+
+    /// The vendor tool leaves undocumented bytes (e.g. 0x48 0x01) in the tails
+    /// of string fields. unpack must save the original RKAF header and pack
+    /// must use it as a template so those bytes survive a round-trip.
+    #[test]
+    fn rkaf_template_preserves_unknown_header_bytes() {
+        let dir = TempDir::new().unwrap();
+        let input = dir.path().join("in");
+        fs::create_dir_all(&input).unwrap();
+        fs::write(input.join("parameter.txt"), b"CMDLINE:x\n").unwrap();
+        fs::write(input.join("userdata.img"), vec![0xAAu8; 100]).unwrap();
+        fs::write(
+            input.join("package-file"),
+            "parameter parameter.txt\nuserdata userdata.img\n",
+        )
+        .unwrap();
+        fs::write(
+            input.join("partition-metadata.txt"),
+            "parameter,parameter.txt,0x00004000,0x00000000,0x00000800,0x00000001,0x00000016\n\
+             userdata,userdata.img,0xffffffff,0x00a98000,0x00001000,0x00000001,0x00000064\n",
+        )
+        .unwrap();
+
+        let img1 = dir.path().join("v1.rkaf");
+        pack_rkaf(input.to_str().unwrap(), img1.to_str().unwrap(), "RK3588", "RK3588").unwrap();
+
+        let unpacked = dir.path().join("unpacked");
+        unpack_file(img1.to_str().unwrap(), unpacked.to_str().unwrap()).unwrap();
+
+        // unpack must persist the original RKAF header
+        let template_path = unpacked.join("rkaf-header.bin");
+        let mut template = fs::read(&template_path).expect("rkaf-header.bin must be saved");
+
+        // Inject vendor-style garbage into string-field tails:
+        // model field tail (abs offset 0x25) and part 1's full_path tail.
+        template[0x25] = 0x48;
+        template[0x26] = 0x01;
+        let part1_path_tail = 140 + 112 + 32 + 59 - 1; // last byte of part 1 full_path
+        template[part1_path_tail] = 0x48;
+        fs::write(&template_path, &template).unwrap();
+
+        // package-file is not a partition in this synthetic image; supply it
+        fs::write(
+            unpacked.join("package-file"),
+            "parameter parameter.txt\nuserdata userdata.img\n",
+        )
+        .unwrap();
+
+        let img2 = dir.path().join("v2.rkaf");
+        pack_rkaf(unpacked.to_str().unwrap(), img2.to_str().unwrap(), "RK3588", "RK3588").unwrap();
+
+        let img = fs::read(&img2).unwrap();
+        assert_eq!(img[0x25], 0x48, "model-field tail byte must survive repack");
+        assert_eq!(img[0x26], 0x01, "model-field tail byte must survive repack");
+        assert_eq!(img[part1_path_tail], 0x48, "path-field tail byte must survive repack");
+        // sanity: the real strings are still intact and NUL-terminated
+        assert_eq!(&img[8..16], b" RK3588\0");
+        assert_eq!(&img[140 + 112..140 + 112 + 9], b"userdata\0");
+    }
+
+    // ---------------- Bug 2 end-to-end: 5 GiB member round-trip ----------------
+    // Expensive (~11 GB of temp disk I/O); run with: cargo test -- --ignored
+
+    #[test]
+    #[ignore]
+    fn rkaf_5gib_member_roundtrips_losslessly() {
+        const FIVE_GIB: u64 = 5 * 1024 * 1024 * 1024;
+
+        let dir = TempDir::new().unwrap();
+        let input = dir.path().join("in");
+        fs::create_dir_all(&input).unwrap();
+
+        // Sparse 5 GiB file with markers at both ends so truncation is detectable
+        let big = input.join("userdata.img");
+        let mut f = File::create(&big).unwrap();
+        f.write_all(b"HEAD").unwrap();
+        f.seek(SeekFrom::Start(FIVE_GIB - 4)).unwrap();
+        f.write_all(b"TAIL").unwrap();
+        drop(f);
+        assert_eq!(fs::metadata(&big).unwrap().len(), FIVE_GIB);
+
+        fs::write(input.join("package-file"), "userdata userdata.img\n").unwrap();
+        // flash_size in sectors (5 GiB / 512 = 0xA00000), padded/byte-count wrapped low-32
+        let wrapped = (FIVE_GIB & 0xFFFF_FFFF) as u32;
+        fs::write(
+            input.join("partition-metadata.txt"),
+            format!(
+                "userdata,userdata.img,{:#010x},{:#010x},{:#010x},{:#010x},{:#010x}\n",
+                0x00A0_0000u32, 0x0000_8000u32, 2048u32, wrapped, wrapped
+            ),
+        )
+        .unwrap();
+
+        let packed = dir.path().join("update.img");
+        pack_rkaf(
+            input.to_str().unwrap(),
+            packed.to_str().unwrap(),
+            "RK3588",
+            "RK3588",
+        )
+        .unwrap();
+
+        // header sector + data (already 2048-aligned) + 4-byte CRC
+        assert_eq!(fs::metadata(&packed).unwrap().len(), 2048 + FIVE_GIB + 4);
+
+        let out = dir.path().join("out");
+        unpack_file(packed.to_str().unwrap(), out.to_str().unwrap()).unwrap();
+
+        let extracted = out.join("userdata.img");
+        assert_eq!(
+            fs::metadata(&extracted).unwrap().len(),
+            FIVE_GIB,
+            "extraction must recover the full 5 GiB, not the wrapped 1 GiB"
+        );
+        let mut f = File::open(&extracted).unwrap();
+        let mut head = [0u8; 4];
+        std::io::Read::read_exact(&mut f, &mut head).unwrap();
+        assert_eq!(&head, b"HEAD");
+        f.seek(SeekFrom::Start(FIVE_GIB - 4)).unwrap();
+        let mut tail = [0u8; 4];
+        std::io::Read::read_exact(&mut f, &mut tail).unwrap();
+        assert_eq!(&tail, b"TAIL");
+    }
+}

--- a/tests/bugfix_tests.rs
+++ b/tests/bugfix_tests.rs
@@ -39,7 +39,7 @@ mod tests {
 
     #[test]
     fn chip_field_decode() {
-        assert_eq!(decode_chip_field(&[b'8', b'8', b'5', b'3']), Some("RK3588".to_string()));
+        assert_eq!(decode_chip_field(b"8853"), Some("RK3588".to_string()));
         assert_eq!(decode_chip_field(&[0x32, b'6', b'5', b'3']), Some("RK3562".to_string()));
         // Legacy family byte with zero padding is not an ASCII-digit field
         assert_eq!(decode_chip_field(&[0x30, 0, 0, 0]), None);
@@ -95,7 +95,7 @@ mod tests {
         h[0x13] = 4;
         h[0x14] = 41;
         // chip RK3588 as ASCII digits reversed
-        h[0x15..0x19].copy_from_slice(&[b'8', b'8', b'5', b'3']);
+        h[0x15..0x19].copy_from_slice(b"8853");
         // BOOT offset/size
         h[0x19..0x1d].copy_from_slice(&(0x66u32).to_le_bytes());
         h[0x1d..0x21].copy_from_slice(&(boot.len() as u32).to_le_bytes());
@@ -142,7 +142,7 @@ mod tests {
         let img = fs::read(&out).unwrap();
         assert_eq!(
             &img[0x15..0x19],
-            &[b'8', b'8', b'5', b'3'],
+            b"8853",
             "chip field must be the four ASCII digits reversed (reads back as 3588)"
         );
     }
@@ -216,7 +216,7 @@ mod tests {
         assert_eq!(rebuilt[6], 4, "build overridden");
         // untouched template fields survive
         assert_eq!(&rebuilt[0x36..0x39], &[0x48, 0x49, 0x01]);
-        assert_eq!(&rebuilt[0x15..0x19], &[b'8', b'8', b'5', b'3']);
+        assert_eq!(&rebuilt[0x15..0x19], b"8853");
     }
 
     #[test]
@@ -334,6 +334,58 @@ mod tests {
         // sanity: the real strings are still intact and NUL-terminated
         assert_eq!(&img[8..16], b" RK3588\0");
         assert_eq!(&img[140 + 112..140 + 112 + 9], b"userdata\0");
+    }
+
+    /// When packing from a saved header template, a MACHINE_ID that has been
+    /// removed from parameter.txt must not leak through from the template:
+    /// the logical id is cleared (NUL first byte) while tail bytes may remain.
+    #[test]
+    fn rkaf_template_id_cleared_when_machine_id_removed() {
+        const ID_OFFSET: usize = 4 + 4 + 34; // magic + length + model
+
+        let dir = TempDir::new().unwrap();
+        let input = dir.path().join("in");
+        fs::create_dir_all(&input).unwrap();
+        fs::write(input.join("parameter.txt"), b"MACHINE_ID: 007\nCMDLINE:x\n").unwrap();
+        fs::write(input.join("userdata.img"), vec![0xAAu8; 100]).unwrap();
+        fs::write(
+            input.join("package-file"),
+            "parameter parameter.txt\nuserdata userdata.img\n",
+        )
+        .unwrap();
+        fs::write(
+            input.join("partition-metadata.txt"),
+            "parameter,parameter.txt,0x00004000,0x00000000,0x00000800,0x00000001,0x00000027\n\
+             userdata,userdata.img,0xffffffff,0x00a98000,0x00001000,0x00000001,0x00000064\n",
+        )
+        .unwrap();
+
+        let img1 = dir.path().join("v1.rkaf");
+        pack_rkaf(input.to_str().unwrap(), img1.to_str().unwrap(), "RK3588", "RK3588").unwrap();
+        assert_eq!(
+            &fs::read(&img1).unwrap()[ID_OFFSET..ID_OFFSET + 5],
+            b" 007\0",
+            "id must be set while MACHINE_ID exists"
+        );
+
+        // Unpack (saves rkaf-header.bin with id " 007"), then remove MACHINE_ID
+        let unpacked = dir.path().join("unpacked");
+        unpack_file(img1.to_str().unwrap(), unpacked.to_str().unwrap()).unwrap();
+        fs::write(unpacked.join("parameter.txt"), b"CMDLINE:x\n").unwrap();
+        fs::write(
+            unpacked.join("package-file"),
+            "parameter parameter.txt\nuserdata userdata.img\n",
+        )
+        .unwrap();
+
+        let img2 = dir.path().join("v2.rkaf");
+        pack_rkaf(unpacked.to_str().unwrap(), img2.to_str().unwrap(), "RK3588", "RK3588").unwrap();
+
+        let img = fs::read(&img2).unwrap();
+        assert_eq!(
+            img[ID_OFFSET], 0,
+            "logical id must be cleared when parameter.txt has no MACHINE_ID"
+        );
     }
 
     /// padded_size is stored in 2048-byte sectors and encodes the TRUE

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -112,7 +112,7 @@ mod integration_tests {
         
         // 运行命令
         let mut cmd = Command::cargo_bin("afptool-rs")?;
-        cmd.arg(&input_path).arg(&output_dir);
+        cmd.arg("unpack").arg(&input_path).arg(&output_dir);
         
         // 执行命令并检查输出
         cmd.assert()

--- a/tests/lib_tests.rs
+++ b/tests/lib_tests.rs
@@ -238,7 +238,7 @@ mod tests {
         // partition-metadata.txt provides flash_size/flash_offset/padded_size;
         // part_byte_count in metadata is not used by pack (recomputed from file)
         let wrapped_size = content.len() as u32 + 12;
-        let padded = ((wrapped_size + 2047) / 2048) * 2048;
+        let padded = wrapped_size.div_ceil(2048) * 2048;
         fs::write(
             input_dir.join("partition-metadata.txt"),
             format!("parameter,parameter.txt,{:#010x},{:#010x},{:#010x},{:#010x},{:#010x}\n",


### PR DESCRIPTION
- Encode modern 4-digit chips as reversed ASCII digits at 0x15-0x18
  (fixes Check Chip Fail: RK3588 images were tagged as 3585); legacy
  RK29xx/RK30xx/RK31xx/RK32xx keep the family-code scheme
- Handle all sizes/offsets as u64: recover true sizes of >4 GiB
  partitions from file layout on unpack (4.5 GiB userdata was silently
  truncated to 512 MiB), emit vendor-style low-32-bit fields on pack
- Save rkfw-header.bin / rkaf-header.bin during unpack and use them as
  templates when repacking, preserving undocumented vendor header bytes;
  pack-rkfw flags are now optional overrides
- Drop RESERVED package-file entries from the RKAF header to match
  official afptool (a phantom all-zero partition entry was emitted)
- Stream pack/unpack in 4 MiB chunks with incremental MD5/CRC instead
  of buffering whole images in memory
- Add regression tests: chip encoding, size recovery, header fidelity,
  RESERVED handling, and a 5 GiB round-trip (run via --ignored)

Validated: unpack + repack of a real 8.28 GB RK3588 vendor image
reproduces the original byte-for-byte.