### PR TITLE
fix: make RKAF header serialization endian-safe

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,32 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Run test suite
+      run: cargo test --all-targets
+
+  miri-big-endian:
+    name: Miri (s390x big-endian)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Miri
+      run: |
+        rustup toolchain install nightly --component miri
+        cargo +nightly miri setup
+
+    - name: Test header serialization on a big-endian target
+      run: cargo +nightly miri test --target s390x-unknown-linux-gnu --test endianness_tests
+
   build:
     strategy:
       matrix:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
-use std::mem;
+use anyhow::{bail, Result};
 mod pack;
 mod unpack;
 
-pub use pack::{pack_rkfw, pack_rkaf, chip_name_to_code, encode_chip_field};
-pub use unpack::{unpack_file, decode_chip_field};
+pub use pack::{chip_name_to_code, encode_chip_field, pack_rkaf, pack_rkfw};
+pub use unpack::{decode_chip_field, unpack_file};
 
 /// Recover a true (possibly >4 GiB) length from an on-disk u32 field that
 /// only stores the low 32 bits. `available` is an upper bound derived from
@@ -22,6 +22,8 @@ pub const RKAFP_MAGIC: &str = "RKAF";
 pub const PARM_MAGIC: &str = "PARM";
 pub const MAX_PARTS: usize = 16;
 pub const MAX_NAME_LEN: usize = 32;
+pub const UPDATE_HEADER_SIZE: usize = 2048;
+const UPDATE_PART_SIZE: usize = 112;
 const MAX_FULL_PATH_LEN: usize = 60;
 const MAX_MODEL_LEN: usize = 34;
 const MAX_ID_LEN: usize = 30;
@@ -30,8 +32,7 @@ pub const RKAF_SIGNATURE: &[u8] = b"RKAF";
 pub const RKFW_SIGNATURE: &[u8] = b"RKFW";
 pub const RKFP_SIGNATURE: &[u8] = b"RKFP";
 
-#[derive(Copy, Clone, Debug)]
-#[repr(C, packed)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct UpdatePart {
     pub name: [u8; MAX_NAME_LEN],
     pub full_path: [u8; MAX_FULL_PATH_LEN],
@@ -42,8 +43,7 @@ pub struct UpdatePart {
     pub part_byte_count: u32,
 }
 
-#[derive(Copy, Clone, Debug)]
-#[repr(C, packed)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct UpdateHeader {
     pub magic: [u8; 4],
     pub length: u32,
@@ -55,13 +55,6 @@ pub struct UpdateHeader {
     pub num_parts: u32,
     pub parts: [UpdatePart; MAX_PARTS],
     reserved: [u8; 116],
-}
-
-#[derive(Copy, Clone, Debug)]
-#[repr(C, packed)]
-pub struct ParamHeader {
-    magic: [u8; 4],
-    length: u32,
 }
 
 impl Default for UpdateHeader {
@@ -82,12 +75,70 @@ impl Default for UpdateHeader {
 }
 
 impl UpdateHeader {
-    pub fn from_bytes(bytes: &[u8]) -> &UpdateHeader {
-        unsafe { &*(bytes.as_ptr() as *const UpdateHeader) }
+    /// Decode an RKAF header from its fixed-size little-endian on-disk format.
+    pub fn decode(bytes: &[u8]) -> Result<Self> {
+        if bytes.len() < UPDATE_HEADER_SIZE {
+            bail!(
+                "RKAF header requires at least {UPDATE_HEADER_SIZE} bytes, got {}",
+                bytes.len()
+            );
+        }
+
+        let bytes = &bytes[..UPDATE_HEADER_SIZE];
+        let mut header = Self::default();
+        header.magic.copy_from_slice(&bytes[0..4]);
+        header.length = read_u32_le(bytes, 4);
+        header.model.copy_from_slice(&bytes[8..42]);
+        header.id.copy_from_slice(&bytes[42..72]);
+        header.manufacturer.copy_from_slice(&bytes[72..128]);
+        header.unknown1 = read_u32_le(bytes, 128);
+        header.version = read_u32_le(bytes, 132);
+        header.num_parts = read_u32_le(bytes, 136);
+
+        if header.num_parts as usize > MAX_PARTS {
+            bail!(
+                "RKAF header contains {} partitions, maximum is {MAX_PARTS}",
+                header.num_parts
+            );
+        }
+
+        for (index, part) in header.parts.iter_mut().enumerate() {
+            let start = 140 + index * UPDATE_PART_SIZE;
+            *part = UpdatePart::decode(&bytes[start..start + UPDATE_PART_SIZE]);
+        }
+        header
+            .reserved
+            .copy_from_slice(&bytes[1932..UPDATE_HEADER_SIZE]);
+
+        Ok(header)
     }
 
-    pub fn to_bytes(&self) -> &[u8] {
-        unsafe { std::slice::from_raw_parts(self as *const _ as *const u8, mem::size_of::<UpdateHeader>()) }
+    /// Encode this RKAF header into its fixed-size little-endian on-disk format.
+    pub fn encode(&self) -> Result<[u8; UPDATE_HEADER_SIZE]> {
+        if self.num_parts as usize > MAX_PARTS {
+            bail!(
+                "cannot encode {} RKAF partitions, maximum is {MAX_PARTS}",
+                self.num_parts
+            );
+        }
+
+        let mut bytes = [0u8; UPDATE_HEADER_SIZE];
+        bytes[0..4].copy_from_slice(&self.magic);
+        write_u32_le(&mut bytes, 4, self.length);
+        bytes[8..42].copy_from_slice(&self.model);
+        bytes[42..72].copy_from_slice(&self.id);
+        bytes[72..128].copy_from_slice(&self.manufacturer);
+        write_u32_le(&mut bytes, 128, self.unknown1);
+        write_u32_le(&mut bytes, 132, self.version);
+        write_u32_le(&mut bytes, 136, self.num_parts);
+
+        for (index, part) in self.parts.iter().enumerate() {
+            let start = 140 + index * UPDATE_PART_SIZE;
+            part.encode_into(&mut bytes[start..start + UPDATE_PART_SIZE]);
+        }
+        bytes[1932..UPDATE_HEADER_SIZE].copy_from_slice(&self.reserved);
+
+        Ok(bytes)
     }
 }
 
@@ -103,6 +154,38 @@ impl Default for UpdatePart {
             part_byte_count: 0,
         }
     }
+}
+
+impl UpdatePart {
+    fn decode(bytes: &[u8]) -> Self {
+        let mut part = Self::default();
+        part.name.copy_from_slice(&bytes[0..32]);
+        part.full_path.copy_from_slice(&bytes[32..92]);
+        part.flash_size = read_u32_le(bytes, 92);
+        part.part_offset = read_u32_le(bytes, 96);
+        part.flash_offset = read_u32_le(bytes, 100);
+        part.padded_size = read_u32_le(bytes, 104);
+        part.part_byte_count = read_u32_le(bytes, 108);
+        part
+    }
+
+    fn encode_into(&self, bytes: &mut [u8]) {
+        bytes[0..32].copy_from_slice(&self.name);
+        bytes[32..92].copy_from_slice(&self.full_path);
+        write_u32_le(bytes, 92, self.flash_size);
+        write_u32_le(bytes, 96, self.part_offset);
+        write_u32_le(bytes, 100, self.flash_offset);
+        write_u32_le(bytes, 104, self.padded_size);
+        write_u32_le(bytes, 108, self.part_byte_count);
+    }
+}
+
+fn read_u32_le(bytes: &[u8], offset: usize) -> u32 {
+    u32::from_le_bytes(bytes[offset..offset + 4].try_into().unwrap())
+}
+
+fn write_u32_le(bytes: &mut [u8], offset: usize, value: u32) {
+    bytes[offset..offset + 4].copy_from_slice(&value.to_le_bytes());
 }
 
 pub fn info_and_fatal(is_fatal: bool, message: String) {
@@ -129,16 +212,4 @@ macro_rules! fatal {
     ($($arg:tt)*) => {
         info_and_fatal(true, format!($($arg)*));
     };
-}
-
-/// # Safety
-///
-/// The returned slice exposes the raw bytes of `p`, including any padding
-/// bytes, which may be uninitialized. Only call this on `#[repr(C, packed)]`
-/// types with no padding (such as the header structs in this crate).
-pub unsafe fn any_as_u8_slice<T: Sized>(p: &T) -> &[u8] {
-    core::slice::from_raw_parts(
-        (p as *const T) as *const u8,
-        mem::size_of::<T>(),
-    )
 }

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -1,9 +1,9 @@
 use std::fs::File;
 use std::io::{Read, Write, BufRead, BufReader, BufWriter, Seek};
 use std::collections::HashMap;
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use chrono::{Datelike, Timelike};
-use crate::{UpdateHeader, RKFW_SIGNATURE, RKAF_SIGNATURE};
+use crate::{UpdateHeader, RKFW_SIGNATURE, RKAF_SIGNATURE, UPDATE_HEADER_SIZE};
 
 #[derive(Debug, Clone)]
 struct PartitionMetadata {
@@ -417,9 +417,8 @@ pub fn pack_rkaf(input_dir: &str, output_file: &str, model: &str, manufacturer: 
     // fields) survive; the fields below are overwritten with computed values.
     let template_path = format!("{}/rkaf-header.bin", input_dir);
     let mut header = match std::fs::read(&template_path) {
-        Ok(data) if data.len() >= std::mem::size_of::<UpdateHeader>() => {
-            *UpdateHeader::from_bytes(&data)
-        }
+        Ok(data) if data.len() >= UPDATE_HEADER_SIZE => UpdateHeader::decode(&data)
+            .with_context(|| format!("Invalid RKAF header template: {template_path}"))?,
         _ => UpdateHeader {
             version: 0x01000000,
             ..Default::default()
@@ -455,7 +454,7 @@ pub fn pack_rkaf(input_dir: &str, output_file: &str, model: &str, manufacturer: 
         return Err(anyhow!("Missing partition metadata"));
     }
 
-    let header_size = std::mem::size_of::<UpdateHeader>() as u64;
+    let header_size = UPDATE_HEADER_SIZE as u64;
     let sector_size: u64 = 2048;
     let data_start = header_size.div_ceil(sector_size) * sector_size;
     let mut current_offset = data_start;
@@ -583,7 +582,8 @@ pub fn pack_rkaf(input_dir: &str, output_file: &str, model: &str, manufacturer: 
         Ok(())
     };
 
-    emit(&mut out_file, &mut checksum, header.to_bytes())?;
+    let encoded_header = header.encode()?;
+    emit(&mut out_file, &mut checksum, &encoded_header)?;
     if data_start > header_size {
         emit(&mut out_file, &mut checksum, &vec![0u8; (data_start - header_size) as usize])?;
     }

--- a/src/unpack.rs
+++ b/src/unpack.rs
@@ -3,7 +3,7 @@ use std::io::{Read, Seek, Write};
 use std::path::Path;
 use anyhow::{anyhow, Result};
 use chrono::NaiveDateTime;
-use crate::{RKAF_SIGNATURE, RKFW_SIGNATURE, UpdateHeader, RKAFP_MAGIC};
+use crate::{RKAF_SIGNATURE, RKFW_SIGNATURE, UpdateHeader, RKAFP_MAGIC, UPDATE_HEADER_SIZE};
 
 pub fn unpack_file(file_path: &str, dst_path: &str) -> Result<()> {
     let mut file = File::open(file_path)?;
@@ -212,12 +212,10 @@ fn parm_content_range(name: &str, fp: &mut File, offset: u64, len: u64) -> Resul
 }
 
 fn unpack_rkafp(file_path: &str, dst_path: &str) -> Result<()> {
-    use std::mem;
-
     let mut fp = File::open(file_path)?;
-    let mut buf = vec![0u8; mem::size_of::<UpdateHeader>()];
+    let mut buf = [0u8; UPDATE_HEADER_SIZE];
     fp.read_exact(&mut buf)?;
-    let header = UpdateHeader::from_bytes(&buf);
+    let header = UpdateHeader::decode(&buf)?;
     let magic_str = std::str::from_utf8(&header.magic)?;
     if magic_str != RKAFP_MAGIC {
         return Err(anyhow!("Invalid header magic id"));
@@ -225,14 +223,6 @@ fn unpack_rkafp(file_path: &str, dst_path: &str) -> Result<()> {
 
     let filesize = fp.metadata()?.len();
     println!("Filesize: {}", filesize);
-
-    if header.num_parts as usize > crate::MAX_PARTS {
-        return Err(anyhow!(
-            "Corrupt header: {} partitions (maximum is {})",
-            header.num_parts as u32,
-            crate::MAX_PARTS
-        ));
-    }
 
     // The length field only stores the low 32 bits, so compare modulo 2^32.
     let container_end = filesize.saturating_sub(4); // trailing CRC

--- a/tests/endianness_tests.rs
+++ b/tests/endianness_tests.rs
@@ -1,0 +1,105 @@
+use afptool_rs::{UpdateHeader, UpdatePart, MAX_PARTS, RKAF_SIGNATURE, UPDATE_HEADER_SIZE};
+
+const PARTS_OFFSET: usize = 140;
+const PART_SIZE: usize = 112;
+
+#[test]
+fn decodes_little_endian_numeric_fields() {
+    let mut bytes = [0u8; UPDATE_HEADER_SIZE];
+    bytes[0..4].copy_from_slice(RKAF_SIGNATURE);
+    bytes[4..8].copy_from_slice(&[0x78, 0x56, 0x34, 0x12]);
+    bytes[128..132].copy_from_slice(&[0x04, 0x03, 0x02, 0x01]);
+    bytes[132..136].copy_from_slice(&[0x44, 0x33, 0x22, 0x11]);
+    bytes[136..140].copy_from_slice(&1u32.to_le_bytes());
+
+    let numeric = PARTS_OFFSET + 92;
+    bytes[numeric..numeric + 4].copy_from_slice(&[0xef, 0xcd, 0xab, 0x89]);
+    bytes[numeric + 4..numeric + 8].copy_from_slice(&[0x10, 0x32, 0x54, 0x76]);
+    bytes[numeric + 8..numeric + 12].copy_from_slice(&[0x98, 0xba, 0xdc, 0xfe]);
+    bytes[numeric + 12..numeric + 16].copy_from_slice(&[0x0d, 0x0c, 0x0b, 0x0a]);
+    bytes[numeric + 16..numeric + 20].copy_from_slice(&[0x40, 0x30, 0x20, 0x10]);
+
+    let header = UpdateHeader::decode(&bytes).unwrap();
+    assert_eq!(header.length, 0x1234_5678);
+    assert_eq!(header.unknown1, 0x0102_0304);
+    assert_eq!(header.version, 0x1122_3344);
+    assert_eq!(header.num_parts, 1);
+    assert_eq!(header.parts[0].flash_size, 0x89ab_cdef);
+    assert_eq!(header.parts[0].part_offset, 0x7654_3210);
+    assert_eq!(header.parts[0].flash_offset, 0xfedc_ba98);
+    assert_eq!(header.parts[0].padded_size, 0x0a0b_0c0d);
+    assert_eq!(header.parts[0].part_byte_count, 0x1020_3040);
+}
+
+#[test]
+fn encodes_little_endian_numeric_fields() {
+    let mut header = UpdateHeader::default();
+    header.magic = *b"RKAF";
+    header.length = 0x1234_5678;
+    header.unknown1 = 0x0102_0304;
+    header.version = 0x1122_3344;
+    header.num_parts = 1;
+    header.parts[0] = UpdatePart {
+        flash_size: 0x89ab_cdef,
+        part_offset: 0x7654_3210,
+        flash_offset: 0xfedc_ba98,
+        padded_size: 0x0a0b_0c0d,
+        part_byte_count: 0x1020_3040,
+        ..Default::default()
+    };
+
+    let bytes = header.encode().unwrap();
+    assert_eq!(&bytes[4..8], &[0x78, 0x56, 0x34, 0x12]);
+    assert_eq!(&bytes[128..132], &[0x04, 0x03, 0x02, 0x01]);
+    assert_eq!(&bytes[132..136], &[0x44, 0x33, 0x22, 0x11]);
+    assert_eq!(&bytes[136..140], &[1, 0, 0, 0]);
+
+    let numeric = PARTS_OFFSET + 92;
+    assert_eq!(&bytes[numeric..numeric + 4], &[0xef, 0xcd, 0xab, 0x89]);
+    assert_eq!(&bytes[numeric + 4..numeric + 8], &[0x10, 0x32, 0x54, 0x76]);
+    assert_eq!(&bytes[numeric + 8..numeric + 12], &[0x98, 0xba, 0xdc, 0xfe]);
+    assert_eq!(
+        &bytes[numeric + 12..numeric + 16],
+        &[0x0d, 0x0c, 0x0b, 0x0a]
+    );
+    assert_eq!(
+        &bytes[numeric + 16..numeric + 20],
+        &[0x40, 0x30, 0x20, 0x10]
+    );
+}
+
+#[test]
+fn decode_encode_preserves_every_header_byte() {
+    let mut bytes = std::array::from_fn(|index| (index as u8).wrapping_mul(37));
+    bytes[136..140].copy_from_slice(&(MAX_PARTS as u32).to_le_bytes());
+
+    let header = UpdateHeader::decode(&bytes).unwrap();
+    assert_eq!(header.encode().unwrap(), bytes);
+}
+
+#[test]
+fn rejects_short_headers_and_invalid_partition_counts() {
+    let short = [0u8; UPDATE_HEADER_SIZE - 1];
+    let error = UpdateHeader::decode(&short).unwrap_err().to_string();
+    assert!(error.contains("requires at least 2048 bytes"));
+
+    let mut bytes = [0u8; UPDATE_HEADER_SIZE];
+    bytes[136..140].copy_from_slice(&((MAX_PARTS + 1) as u32).to_le_bytes());
+    let error = UpdateHeader::decode(&bytes).unwrap_err().to_string();
+    assert!(error.contains("maximum is 16"));
+
+    let mut header = UpdateHeader::default();
+    header.num_parts = (MAX_PARTS + 1) as u32;
+    let error = header.encode().unwrap_err().to_string();
+    assert!(error.contains("maximum is 16"));
+}
+
+#[test]
+fn accepts_trailing_container_bytes_without_serializing_them() {
+    let mut bytes = vec![0u8; UPDATE_HEADER_SIZE + PART_SIZE];
+    bytes[..4].copy_from_slice(RKAF_SIGNATURE);
+    bytes[UPDATE_HEADER_SIZE..].fill(0xa5);
+
+    let header = UpdateHeader::decode(&bytes).unwrap();
+    assert_eq!(header.encode().unwrap(), bytes[..UPDATE_HEADER_SIZE]);
+}

--- a/tests/lib_tests.rs
+++ b/tests/lib_tests.rs
@@ -3,7 +3,10 @@ mod tests {
     use std::fs::{self, File};
     use std::io::Write;
     use std::path::Path;
-    use afptool_rs::{pack_rkaf, unpack_file, RKAF_SIGNATURE, RKFW_SIGNATURE, UpdateHeader, UpdatePart};
+    use afptool_rs::{
+        pack_rkaf, unpack_file, RKAF_SIGNATURE, RKFW_SIGNATURE, UPDATE_HEADER_SIZE,
+        UpdateHeader, UpdatePart,
+    };
     use tempfile::TempDir;
 
     // 创建模拟的 RKFW 文件用于测试
@@ -93,9 +96,9 @@ mod tests {
     }
 
     #[test]
-    fn test_update_header_from_bytes() {
+    fn test_update_header_decode() {
         let mock_rkaf = create_mock_rkaf();
-        let header = UpdateHeader::from_bytes(&mock_rkaf);
+        let header = UpdateHeader::decode(&mock_rkaf).unwrap();
         
         assert_eq!(&header.magic, RKAF_SIGNATURE);
         // 使用临时变量避免 packed struct 对齐问题
@@ -116,7 +119,7 @@ mod tests {
     }
     
     #[test]
-    fn test_update_header_to_bytes() {
+    fn test_update_header_encode() {
         let mut header = UpdateHeader::default();
         header.magic.copy_from_slice(RKAF_SIGNATURE);
         header.length = 0x800;
@@ -128,7 +131,7 @@ mod tests {
         let model = b"RK3326";
         header.model[..model.len()].copy_from_slice(model);
         
-        let bytes = header.to_bytes();
+        let bytes = header.encode().unwrap();
         assert_eq!(&bytes[0..4], RKAF_SIGNATURE);
         
         // 检查长度
@@ -178,8 +181,6 @@ mod tests {
 
     #[test]
     fn test_parm_header_stripped_on_extract() {
-        use std::mem;
-
         let temp_dir = TempDir::new().unwrap();
         let input_path = temp_dir.path().join("test.rkaf");
         let output_dir = temp_dir.path().join("out");
@@ -194,7 +195,7 @@ mod tests {
         parm_data.extend_from_slice(content);
         parm_data.extend_from_slice(&[0u8; 4]); // CRC
 
-        let header_size = mem::size_of::<UpdateHeader>();
+        let header_size = UPDATE_HEADER_SIZE;
 
         let mut header = UpdateHeader::default();
         header.magic.copy_from_slice(RKAF_SIGNATURE);
@@ -209,7 +210,7 @@ mod tests {
         part.part_byte_count = parm_data.len() as u32;
         header.parts[0] = part;
 
-        let mut file_data: Vec<u8> = header.to_bytes().to_vec();
+        let mut file_data: Vec<u8> = header.encode().unwrap().to_vec();
         file_data.extend_from_slice(&parm_data);
         file_data.extend_from_slice(&[0u8; 4]); // RKAF trailing CRC
 
@@ -263,8 +264,6 @@ mod tests {
 
     #[test]
     fn test_parameter_roundtrip() {
-        use std::mem;
-
         let temp_dir = TempDir::new().unwrap();
         let content = b"CMDLINE:console=ttyFIQ0,1500000\n";
 
@@ -280,7 +279,7 @@ mod tests {
         parm_data.extend_from_slice(content);
         parm_data.extend_from_slice(&[0u8; 4]); // CRC
 
-        let header_size = mem::size_of::<UpdateHeader>();
+        let header_size = UPDATE_HEADER_SIZE;
         let mut header = UpdateHeader::default();
         header.magic.copy_from_slice(RKAF_SIGNATURE);
         header.num_parts = 1;
@@ -293,7 +292,7 @@ mod tests {
         part.part_byte_count = parm_data.len() as u32;
         header.parts[0] = part;
 
-        let mut file_data: Vec<u8> = header.to_bytes().to_vec();
+        let mut file_data: Vec<u8> = header.encode().unwrap().to_vec();
         file_data.extend_from_slice(&parm_data);
         file_data.extend_from_slice(&[0u8; 4]);
         fs::write(&input_rkaf, &file_data).unwrap();


### PR DESCRIPTION
## Summary

- replace host-layout casts with explicit little-endian RKAF header encoding and decoding
- validate header length and partition count while preserving unknown and reserved bytes losslessly
- migrate pack/unpack paths to the safe owned header API
- add stable test coverage and an s390x big-endian Miri CI job

## Public API changes

- replace `UpdateHeader::from_bytes` with `UpdateHeader::decode`
- replace `UpdateHeader::to_bytes` with `UpdateHeader::encode`
- add `UPDATE_HEADER_SIZE`
- remove raw-memory serialization helpers and packed layout requirements

## Verification

- `cargo test --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `cargo +nightly miri test --target s390x-unknown-linux-gnu --test endianness_tests`

Fixes #17
